### PR TITLE
:bug: Stop right details panel from auto-growing to max width

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,10 +79,13 @@ cargo build --release
 
 ## Features (Planned, the order is approximate)
 
-- [ ] Display bug on further right column
+- [ ] Revert the details-panel custom resize handle once [emilk/egui#8056](https://github.com/emilk/egui/pull/8056) ships in an egui release (re-enable `Panel::right(...).resizable(true)`)
 - [ ] Retry all button next to Clear completed
 - [ ] closing the app clears all tasks including running : maybe at least ask confirmation, then maybe backup?
 - [ ] Ability to change column order by grabbing them
+- [ ] Make folders of shelves
+- [ ] Shelves or shelf folders can be pinned to top (with a pin icon)
+- [ ] Ficflow remembers which library/shelf tab was open when closed and reopens the same one
 - [ ] Ability to choose the text size / zoom level in the settings
 - [ ] New feature of auto-shelves (based on ships, fandoms, relationship,...)
 - [ ] Possibility to choose the location of the library (defaults to appdata/ ~/.ficflow like now), with persistence of that config

--- a/src/interfaces/gui/app.rs
+++ b/src/interfaces/gui/app.rs
@@ -771,11 +771,11 @@ impl FicflowApp {
             egui::Id::new("ficflow-details-resize-handle"),
             egui::Sense::drag(),
         );
-        if handle_resp.dragged() {
-            if let Some(pointer) = handle_resp.interact_pointer_pos() {
-                let new_w = (host_after.right() + panel_width - pointer.x).clamp(MIN_W, MAX_W);
-                self.details_panel_width = new_w;
-            }
+        if handle_resp.dragged()
+            && let Some(pointer) = handle_resp.interact_pointer_pos()
+        {
+            let new_w = (host_after.right() + panel_width - pointer.x).clamp(MIN_W, MAX_W);
+            self.details_panel_width = new_w;
         }
         if handle_resp.hovered() || handle_resp.dragged() {
             host.ctx()

--- a/src/interfaces/gui/app.rs
+++ b/src/interfaces/gui/app.rs
@@ -55,6 +55,13 @@ pub struct FicflowApp {
     /// Set by Ctrl+F; consumed by `draw_search_field` on next paint.
     focus_search_pending: bool,
     toasts: Toasts,
+    /// Details panel width — managed locally instead of via egui's
+    /// `PanelState` to side-step egui#8055 (resizable panel stores an
+    /// overflowed rect, then grows by that overflow every frame until
+    /// it pegs at `size_range.max`). We pin the panel with
+    /// `exact_size(details_panel_width)` and drive resizing through a
+    /// custom drag handle in `paint_details_panel`.
+    details_panel_width: f32,
 }
 
 #[derive(Debug)]
@@ -144,6 +151,7 @@ impl FicflowApp {
             task_filter: TaskFilter::default(),
             focus_search_pending: false,
             toasts: Toasts::default(),
+            details_panel_width: 320.0,
         })
     }
 
@@ -719,11 +727,22 @@ impl FicflowApp {
         let Some(fic) = self.cache.fics.iter().find(|f| f.id == id).cloned() else {
             return;
         };
+
+        // egui#8055 workaround: we don't use the built-in `.resizable(true)`
+        // because that path persists the panel's actual rendered rect (which
+        // can extend past the clip when content overflows) and feeds the
+        // overflow back as next-frame width — growing the panel until it
+        // pegs at the max. Instead we pin the panel to `exact_size` and run
+        // our own drag handle. Width is kept in `FicflowApp` so it survives
+        // selection toggles without touching `PanelState`.
+        const MIN_W: f32 = 280.0;
+        const MAX_W: f32 = 900.0;
+        let panel_width = self.details_panel_width.clamp(MIN_W, MAX_W);
+
         let mut outcome = details_panel::Outcome::None;
-        egui::Panel::right("ficflow-details")
-            .default_size(320.0)
-            .size_range(280.0..=900.0)
-            .resizable(true)
+        egui::Panel::right("ficflow-details-v2")
+            .exact_size(panel_width)
+            .resizable(false)
             .show_inside(host, |ui| {
                 outcome = details_panel::draw(
                     ui,
@@ -734,6 +753,35 @@ impl FicflowApp {
                     },
                 );
             });
+
+        // Custom drag handle on the panel's left edge. `available_rect_before_wrap`
+        // here is what's left after the panel was placed, so its right edge is
+        // exactly the panel's left edge.
+        let host_after = host.available_rect_before_wrap();
+        let handle_x = host_after.right();
+        let panel_top = host_after.top();
+        let panel_bottom = host_after.bottom();
+        let handle_grab = host.style().interaction.resize_grab_radius_side;
+        let handle_rect = egui::Rect::from_min_max(
+            egui::pos2(handle_x - handle_grab, panel_top),
+            egui::pos2(handle_x + handle_grab, panel_bottom),
+        );
+        let handle_resp = host.interact(
+            handle_rect,
+            egui::Id::new("ficflow-details-resize-handle"),
+            egui::Sense::drag(),
+        );
+        if handle_resp.dragged() {
+            if let Some(pointer) = handle_resp.interact_pointer_pos() {
+                let new_w = (host_after.right() + panel_width - pointer.x).clamp(MIN_W, MAX_W);
+                self.details_panel_width = new_w;
+            }
+        }
+        if handle_resp.hovered() || handle_resp.dragged() {
+            host.ctx()
+                .set_cursor_icon(egui::CursorIcon::ResizeHorizontal);
+        }
+
         self.dispatch_details_outcome(id, outcome);
     }
 

--- a/src/interfaces/gui/views/details_panel.rs
+++ b/src/interfaces/gui/views/details_panel.rs
@@ -461,14 +461,19 @@ fn bubble_list(ui: &mut Ui, salt: &str, items: &[String]) {
 /// `horizontal_wrapped`'s wrap mode and fractures into one character
 /// per line in tight space. The manual measure → allocate → paint
 /// flow keeps the bubble atomic.
+///
+/// `break_anywhere = true` on the layout job: AO3 tags can contain
+/// long unbreakable segments (slash-joined character names, etc.).
+/// Without it the layouter renders the text wider than `max_text_w`,
+/// the bubble allocates beyond the panel's clip rect, and the panel
+/// stores the overflowed rect in `PanelState` — egui #8055 then makes
+/// the panel grow by that much every frame until it pegs at the max.
 fn bubble(ui: &mut Ui, text: &str) {
     let font = egui::FontId::proportional(12.0);
     let text_color = ui.visuals().text_color();
     let pad = egui::vec2(8.0, 2.0);
     let max_text_w = (ui.max_rect().width() - pad.x * 2.0).max(40.0);
-    let galley = ui
-        .painter()
-        .layout(text.to_string(), font, text_color, max_text_w);
+    let galley = layout_break_anywhere(ui, text, font, text_color, max_text_w);
     let size = galley.size() + pad * 2.0;
     let (rect, _) = ui.allocate_exact_size(size, Sense::hover());
     let fill = ui.visuals().widgets.inactive.weak_bg_fill;
@@ -482,9 +487,7 @@ fn bubble_clickable(ui: &mut Ui, text: &str) -> egui::Response {
     let color = ui.visuals().weak_text_color();
     let pad = egui::vec2(8.0, 2.0);
     let max_text_w = (ui.max_rect().width() - pad.x * 2.0).max(40.0);
-    let galley = ui
-        .painter()
-        .layout(text.to_string(), font, color, max_text_w);
+    let galley = layout_break_anywhere(ui, text, font, color, max_text_w);
     let size = galley.size() + pad * 2.0;
     let (rect, resp) = ui.allocate_exact_size(size, Sense::click());
     let visuals = ui.style().interact(&resp);
@@ -497,6 +500,26 @@ fn bubble_clickable(ui: &mut Ui, text: &str) -> egui::Response {
     );
     ui.painter().galley(rect.min + pad, galley, color);
     resp
+}
+
+fn layout_break_anywhere(
+    ui: &Ui,
+    text: &str,
+    font: egui::FontId,
+    color: Color32,
+    max_width: f32,
+) -> std::sync::Arc<egui::Galley> {
+    let mut job = egui::text::LayoutJob::single_section(
+        text.to_string(),
+        egui::text::TextFormat {
+            font_id: font,
+            color,
+            ..Default::default()
+        },
+    );
+    job.wrap.max_width = max_width;
+    job.wrap.break_anywhere = true;
+    ui.fonts_mut(|f| f.layout_job(job))
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Local fix for an egui bug that should be addressed once emilk/egui#8056 is merged.
Related to the issue emilk/egui#8055