### PR TITLE
:sparkles: Reopen the last viewed library/shelf tab on restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ cargo build --release
 ## Features (Planned, the order is approximate)
 
 - [ ] Revert the details-panel custom resize handle once egui 0.35 is out — the fix ([emilk/egui#8198](https://github.com/emilk/egui/pull/8198), merged 2026-05-26, superseding #8056) was kept out of 0.34.x patch releases (re-enable `Panel::right(...).resizable(true)`). Update : blocked by egui-notify ; they need to have a compatible version with 0.35 egui
-- [ ] Ficflow remembers which library/shelf tab was open when closed and reopens the same one
+- [x] Ficflow remembers which library/shelf tab was open when closed and reopens the same one
 - [ ] Ability to choose the text size / zoom level in the settings
 - [ ] New feature of auto-shelves (based on ships, fandoms, relationship,...)
 - [ ] Possibility to choose the location of the library (defaults to appdata/ ~/.ficflow like now), with persistence of that config

--- a/src/interfaces/gui/app.rs
+++ b/src/interfaces/gui/app.rs
@@ -41,6 +41,9 @@ pub struct FicflowApp {
     cache: LibraryCache,
     chrome: FrameChrome,
     config: AppConfig,
+    /// Where `config` is written back to; `None` means the platform
+    /// config dir. See `FicflowConfig::config_path`.
+    config_path: Option<PathBuf>,
     /// Gate so the persisted maximized / fullscreen state is applied
     /// once at first frame and not re-fired every paint.
     initial_window_state_applied: bool,
@@ -98,6 +101,10 @@ pub enum ActiveModal {
 #[derive(Clone)]
 pub struct FicflowConfig {
     pub db_path: Option<PathBuf>,
+    /// Explicit path for the GUI-preferences TOML file. `None` uses the
+    /// platform config dir (`AppConfig`'s default); tests point this at a
+    /// scratch file so they don't touch the real user config.
+    pub config_path: Option<PathBuf>,
     pub ao3_urls: Vec<String>,
     pub max_retry_cycles: u32,
 }
@@ -107,6 +114,7 @@ impl Default for FicflowConfig {
         let (ao3_urls, max_retry_cycles) = ao3_urls_from_env();
         Self {
             db_path: None,
+            config_path: None,
             ao3_urls,
             max_retry_cycles,
         }
@@ -130,8 +138,12 @@ impl FicflowApp {
         };
         let cache = LibraryCache::load(&connection);
         let chrome = FrameChrome::new().map_err(InitError::Chrome)?;
-        let app_config = AppConfig::load();
+        let app_config = AppConfig::load_from(config.config_path.clone());
         let sort = app_config.default_sort;
+        let current_view = app_config
+            .last_view
+            .and_then(|pv| View::from_persisted(pv, &cache.shelves))
+            .unwrap_or_default();
         let task_executor = TaskExecutor::spawn(
             config.ao3_urls,
             config.max_retry_cycles,
@@ -142,12 +154,13 @@ impl FicflowApp {
             cache,
             chrome,
             config: app_config,
+            config_path: config.config_path.clone(),
             initial_window_state_applied: false,
             sort,
             search_query: String::new(),
             show_column_picker: false,
             selection: SelectionController::new(),
-            current_view: View::default(),
+            current_view,
             active_modal: ActiveModal::None,
             task_executor,
             quit_confirmed: false,
@@ -255,6 +268,10 @@ impl FicflowApp {
 
     pub fn open_view(&mut self, view: View) {
         self.current_view = view;
+        if let Some(persisted) = self.current_view.to_persisted() {
+            self.config.last_view = Some(persisted);
+            self.save_config();
+        }
     }
 
     pub fn refresh_selected(&self) {
@@ -305,7 +322,7 @@ impl FicflowApp {
             Ok(()) => {
                 self.toasts.success("Shelf deleted");
                 if self.current_view == View::Shelf(shelf_id) {
-                    self.current_view = View::AllFics;
+                    self.open_view(View::AllFics);
                     self.cache.shelf_members.clear();
                 }
                 self.cache.reload_shelves(&self.connection);
@@ -480,7 +497,7 @@ impl FicflowApp {
     }
 
     fn save_config(&self) {
-        if let Err(err) = self.config.save() {
+        if let Err(err) = self.config.save(self.config_path.clone()) {
             log::warn!("Failed to save config: {}", err);
         }
     }

--- a/src/interfaces/gui/app.rs
+++ b/src/interfaces/gui/app.rs
@@ -41,9 +41,6 @@ pub struct FicflowApp {
     cache: LibraryCache,
     chrome: FrameChrome,
     config: AppConfig,
-    /// Where `config` is written back to; `None` means the platform
-    /// config dir. See `FicflowConfig::config_path`.
-    config_path: Option<PathBuf>,
     /// Gate so the persisted maximized / fullscreen state is applied
     /// once at first frame and not re-fired every paint.
     initial_window_state_applied: bool,
@@ -101,10 +98,6 @@ pub enum ActiveModal {
 #[derive(Clone)]
 pub struct FicflowConfig {
     pub db_path: Option<PathBuf>,
-    /// Explicit path for the GUI-preferences TOML file. `None` uses the
-    /// platform config dir (`AppConfig`'s default); tests point this at a
-    /// scratch file so they don't touch the real user config.
-    pub config_path: Option<PathBuf>,
     pub ao3_urls: Vec<String>,
     pub max_retry_cycles: u32,
 }
@@ -114,7 +107,6 @@ impl Default for FicflowConfig {
         let (ao3_urls, max_retry_cycles) = ao3_urls_from_env();
         Self {
             db_path: None,
-            config_path: None,
             ao3_urls,
             max_retry_cycles,
         }
@@ -138,7 +130,7 @@ impl FicflowApp {
         };
         let cache = LibraryCache::load(&connection);
         let chrome = FrameChrome::new().map_err(InitError::Chrome)?;
-        let app_config = AppConfig::load_from(config.config_path.clone());
+        let app_config = AppConfig::load();
         let sort = app_config.default_sort;
         let current_view = app_config
             .last_view
@@ -154,7 +146,6 @@ impl FicflowApp {
             cache,
             chrome,
             config: app_config,
-            config_path: config.config_path.clone(),
             initial_window_state_applied: false,
             sort,
             search_query: String::new(),
@@ -511,7 +502,7 @@ impl FicflowApp {
     }
 
     fn save_config(&self) {
-        if let Err(err) = self.config.save(self.config_path.clone()) {
+        if let Err(err) = self.config.save() {
             log::warn!("Failed to save config: {}", err);
         }
     }

--- a/src/interfaces/gui/app.rs
+++ b/src/interfaces/gui/app.rs
@@ -268,6 +268,13 @@ impl FicflowApp {
 
     pub fn open_view(&mut self, view: View) {
         self.current_view = view;
+        self.persist_current_view();
+    }
+
+    /// Saves `current_view` into `AppConfig` if it's a restorable
+    /// (library-facing) view. Called from both `open_view` and the
+    /// sidebar's direct `current_view` mutation (`paint_sidebar`).
+    fn persist_current_view(&mut self) {
         if let Some(persisted) = self.current_view.to_persisted() {
             self.config.last_view = Some(persisted);
             self.save_config();
@@ -810,6 +817,7 @@ impl FicflowApp {
                 self.cache.shelf_members.clear();
             }
             self.prune_selection_to_view();
+            self.persist_current_view();
         }
     }
 

--- a/src/interfaces/gui/app.rs
+++ b/src/interfaces/gui/app.rs
@@ -149,7 +149,7 @@ impl FicflowApp {
             config.max_retry_cycles,
             config.db_path.clone(),
         );
-        Ok(Self {
+        let mut app = Self {
             connection,
             cache,
             chrome,
@@ -168,7 +168,14 @@ impl FicflowApp {
             focus_search_pending: false,
             toasts: Toasts::default(),
             details_panel_width: 320.0,
-        })
+        };
+        // Restoring straight into a shelf view skips the sidebar's
+        // prev/post diff (see `paint_sidebar`) that normally populates
+        // `shelf_members` on a view change, so do it explicitly here.
+        if matches!(app.current_view, View::Shelf(_)) {
+            app.refresh_shelf_members();
+        }
+        Ok(app)
     }
 
     // ---- Read-only accessors ----

--- a/src/interfaces/gui/config.rs
+++ b/src/interfaces/gui/config.rs
@@ -161,15 +161,7 @@ impl AppConfig {
     /// Loads the config from disk. Returns `Default` if the file is missing
     /// or unparseable — never blocks startup on config issues.
     pub fn load() -> Self {
-        Self::load_from(None)
-    }
-
-    /// Same as `load`, but reads from an explicit path if given, falling
-    /// back to the platform config dir when `path` is `None`. Lets
-    /// embedders and integration tests point at a scratch file without
-    /// touching the real user config.
-    pub fn load_from(path: Option<PathBuf>) -> Self {
-        let Some(path) = path.or_else(config_path) else {
+        let Some(path) = config_path() else {
             return Self::default();
         };
         let Ok(text) = std::fs::read_to_string(&path) else {
@@ -205,8 +197,8 @@ impl AppConfig {
     }
 
     /// Writes the config to disk, creating parent directories as needed.
-    pub fn save(&self, path: Option<PathBuf>) -> io::Result<()> {
-        let Some(path) = path.or_else(config_path) else {
+    pub fn save(&self) -> io::Result<()> {
+        let Some(path) = config_path() else {
             return Err(io::Error::new(
                 io::ErrorKind::NotFound,
                 "no config directory available on this platform",

--- a/src/interfaces/gui/config.rs
+++ b/src/interfaces/gui/config.rs
@@ -13,8 +13,20 @@ use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
+use crate::domain::fanfiction::ReadingStatus;
+
 const CONFIG_FILE: &str = "config.toml";
 const APP_DIR: &str = "ficflow";
+
+/// Serializable shadow of the library-facing `View` variants — the ones
+/// worth restoring on next launch. `Tasks` and `Settings` are transient
+/// pages, not "tabs", so they're deliberately excluded.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PersistedView {
+    AllFics,
+    ByStatus(ReadingStatus),
+    Shelf(u64),
+}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ColumnKey {
@@ -115,6 +127,10 @@ pub struct AppConfig {
     pub window_maximized: bool,
     #[serde(default)]
     pub window_fullscreen: bool,
+    /// The library/shelf tab that was open when the app last quit, so it
+    /// reopens the same one next launch.
+    #[serde(default)]
+    pub last_view: Option<PersistedView>,
 }
 
 impl Default for AppConfig {
@@ -136,6 +152,7 @@ impl Default for AppConfig {
             default_sort: SortPref::default(),
             window_maximized: false,
             window_fullscreen: false,
+            last_view: None,
         }
     }
 }
@@ -144,7 +161,14 @@ impl AppConfig {
     /// Loads the config from disk. Returns `Default` if the file is missing
     /// or unparseable — never blocks startup on config issues.
     pub fn load() -> Self {
-        let Some(path) = config_path() else {
+        Self::load_from(config_path())
+    }
+
+    /// Same as `load`, but reads from an explicit path instead of the
+    /// platform config dir. Lets embedders and integration tests point at
+    /// a scratch file without touching the real user config.
+    pub fn load_from(path: Option<PathBuf>) -> Self {
+        let Some(path) = path else {
             return Self::default();
         };
         let Ok(text) = std::fs::read_to_string(&path) else {
@@ -180,8 +204,8 @@ impl AppConfig {
     }
 
     /// Writes the config to disk, creating parent directories as needed.
-    pub fn save(&self) -> io::Result<()> {
-        let Some(path) = config_path() else {
+    pub fn save(&self, path: Option<PathBuf>) -> io::Result<()> {
+        let Some(path) = path.or_else(config_path) else {
             return Err(io::Error::new(
                 io::ErrorKind::NotFound,
                 "no config directory available on this platform",

--- a/src/interfaces/gui/config.rs
+++ b/src/interfaces/gui/config.rs
@@ -161,14 +161,15 @@ impl AppConfig {
     /// Loads the config from disk. Returns `Default` if the file is missing
     /// or unparseable — never blocks startup on config issues.
     pub fn load() -> Self {
-        Self::load_from(config_path())
+        Self::load_from(None)
     }
 
-    /// Same as `load`, but reads from an explicit path instead of the
-    /// platform config dir. Lets embedders and integration tests point at
-    /// a scratch file without touching the real user config.
+    /// Same as `load`, but reads from an explicit path if given, falling
+    /// back to the platform config dir when `path` is `None`. Lets
+    /// embedders and integration tests point at a scratch file without
+    /// touching the real user config.
     pub fn load_from(path: Option<PathBuf>) -> Self {
-        let Some(path) = path else {
+        let Some(path) = path.or_else(config_path) else {
             return Self::default();
         };
         let Ok(text) = std::fs::read_to_string(&path) else {

--- a/src/interfaces/gui/view.rs
+++ b/src/interfaces/gui/view.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 
+use super::config::PersistedView;
 use crate::domain::fanfiction::{Fanfiction, ReadingStatus};
 use crate::domain::shelf::Shelf;
 
@@ -54,5 +55,30 @@ impl View {
     /// True when this view shows the library table at all (vs. a stub page).
     pub fn shows_library(&self) -> bool {
         matches!(self, View::AllFics | View::ByStatus(_) | View::Shelf(_))
+    }
+
+    /// Converts to the persistable subset of views, or `None` for `Tasks`
+    /// and `Settings`, which aren't "tabs" worth restoring on next launch.
+    pub fn to_persisted(&self) -> Option<PersistedView> {
+        match self {
+            View::AllFics => Some(PersistedView::AllFics),
+            View::ByStatus(status) => Some(PersistedView::ByStatus(*status)),
+            View::Shelf(id) => Some(PersistedView::Shelf(*id)),
+            View::Tasks | View::Settings => None,
+        }
+    }
+
+    /// Resolves a persisted view against the currently loaded shelves,
+    /// falling back to `None` if a persisted shelf id no longer exists
+    /// (the shelf was deleted since the config was last saved).
+    pub fn from_persisted(persisted: PersistedView, shelves: &[Shelf]) -> Option<Self> {
+        match persisted {
+            PersistedView::AllFics => Some(View::AllFics),
+            PersistedView::ByStatus(status) => Some(View::ByStatus(status)),
+            PersistedView::Shelf(id) => shelves
+                .iter()
+                .any(|s| s.id == id)
+                .then_some(View::Shelf(id)),
+        }
     }
 }

--- a/tests/gui.rs
+++ b/tests/gui.rs
@@ -42,3 +42,6 @@ mod quit_confirm;
 
 #[path = "gui/columns.rs"]
 mod columns;
+
+#[path = "gui/last_view.rs"]
+mod last_view;

--- a/tests/gui/harness.rs
+++ b/tests/gui/harness.rs
@@ -17,6 +17,7 @@
 #![allow(dead_code)] // Suppress warnings for harness helpers used by future test files
 
 use std::path::PathBuf;
+use std::sync::{Mutex, MutexGuard};
 use std::time::Duration;
 
 use rusqlite::Connection;
@@ -26,6 +27,14 @@ use ficflow::interfaces::gui::{FicflowApp, FicflowConfig};
 
 use crate::common::fixtures;
 
+/// `AppConfig` reads `XDG_CONFIG_HOME` (via `dirs_next`, Linux-only — this
+/// suite only runs on Linux, see `.github/workflows/test.yml`) to find
+/// `config.toml`; overriding it per-harness keeps tests off the developer's
+/// real `~/.config/ficflow/config.toml`. It's process-global state, so this
+/// lock serializes every `GuiHarness` for the harness's whole lifetime
+/// (held via the guard below) instead of gating just the `set_var` call.
+static CONFIG_ENV_LOCK: Mutex<()> = Mutex::new(());
+
 pub struct GuiHarness {
     pub app: FicflowApp,
     pub ctx: egui::Context,
@@ -33,12 +42,12 @@ pub struct GuiHarness {
     /// Lets tests seed fixtures and assert against the underlying DB.
     pub conn: Connection,
     pub db_path: PathBuf,
-    /// Scratch GUI-preferences file this harness's app reads/writes —
-    /// exposed so tests can rebuild a `FicflowApp` against the same file
-    /// to exercise config persistence across a simulated restart.
-    pub config_path: PathBuf,
     /// Held so the temp file doesn't get unlinked until the harness drops.
     _temp_dir: TempDir,
+    /// Keeps `XDG_CONFIG_HOME` pinned to this harness's scratch dir for as
+    /// long as the harness lives — released (and the lock freed for the
+    /// next test) on drop.
+    _config_env_guard: MutexGuard<'static, ()>,
 }
 
 impl GuiHarness {
@@ -60,13 +69,22 @@ impl GuiHarness {
         db_path: PathBuf,
         temp_dir: TempDir,
     ) -> Self {
+        // A poisoned lock (previous test panicked while holding it) is
+        // still safe to reuse here — we're about to overwrite the env var
+        // ourselves regardless of what state it was left in.
+        let config_env_guard = CONFIG_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        // SAFETY: serialized by `CONFIG_ENV_LOCK`, held for this harness's
+        // whole lifetime, so no other thread reads/writes the env at the
+        // same time.
+        unsafe {
+            std::env::set_var("XDG_CONFIG_HOME", temp_dir.path());
+        }
+
         let ctx = egui::Context::default();
-        let config_path = temp_dir.path().join("config.toml");
         let config = FicflowConfig {
             db_path: Some(db_path.clone()),
-            // Scratch file next to the temp DB so tests never touch the
-            // developer's real `~/.config/ficflow/config.toml`.
-            config_path: Some(config_path.clone()),
             ao3_urls,
             // Fail-fast: tests should never sit through the production
             // 2- or 3-cycle retry storm.
@@ -79,17 +97,17 @@ impl GuiHarness {
             ctx,
             conn,
             db_path,
-            config_path,
             _temp_dir: temp_dir,
+            _config_env_guard: config_env_guard,
         }
     }
 
     /// Rebuilds `self.app` against the same DB and config file, simulating
-    /// an app restart. `self.conn` and `self.ctx` are unaffected.
+    /// an app restart. `self.conn`, `self.ctx`, and the `XDG_CONFIG_HOME`
+    /// override are unaffected.
     pub fn restart(&mut self, ao3_urls: Vec<String>) {
         let config = FicflowConfig {
             db_path: Some(self.db_path.clone()),
-            config_path: Some(self.config_path.clone()),
             ao3_urls,
             max_retry_cycles: 1,
         };

--- a/tests/gui/harness.rs
+++ b/tests/gui/harness.rs
@@ -33,6 +33,10 @@ pub struct GuiHarness {
     /// Lets tests seed fixtures and assert against the underlying DB.
     pub conn: Connection,
     pub db_path: PathBuf,
+    /// Scratch GUI-preferences file this harness's app reads/writes —
+    /// exposed so tests can rebuild a `FicflowApp` against the same file
+    /// to exercise config persistence across a simulated restart.
+    pub config_path: PathBuf,
     /// Held so the temp file doesn't get unlinked until the harness drops.
     _temp_dir: TempDir,
 }
@@ -57,8 +61,12 @@ impl GuiHarness {
         temp_dir: TempDir,
     ) -> Self {
         let ctx = egui::Context::default();
+        let config_path = temp_dir.path().join("config.toml");
         let config = FicflowConfig {
             db_path: Some(db_path.clone()),
+            // Scratch file next to the temp DB so tests never touch the
+            // developer's real `~/.config/ficflow/config.toml`.
+            config_path: Some(config_path.clone()),
             ao3_urls,
             // Fail-fast: tests should never sit through the production
             // 2- or 3-cycle retry storm.
@@ -71,8 +79,22 @@ impl GuiHarness {
             ctx,
             conn,
             db_path,
+            config_path,
             _temp_dir: temp_dir,
         }
+    }
+
+    /// Rebuilds `self.app` against the same DB and config file, simulating
+    /// an app restart. `self.conn` and `self.ctx` are unaffected.
+    pub fn restart(&mut self, ao3_urls: Vec<String>) {
+        let config = FicflowConfig {
+            db_path: Some(self.db_path.clone()),
+            config_path: Some(self.config_path.clone()),
+            ao3_urls,
+            max_retry_cycles: 1,
+        };
+        self.app = FicflowApp::with_config(&self.ctx, config)
+            .expect("FicflowApp::with_config failed on restart");
     }
 
     /// Run one frame with no input. Discards `FullOutput` — tests that

--- a/tests/gui/last_view.rs
+++ b/tests/gui/last_view.rs
@@ -74,4 +74,23 @@ mod tests {
         let h = given_harness();
         assert_eq!(*h.app.current_view(), View::AllFics);
     }
+
+    /// G6 — restoring straight into a shelf view on startup must also
+    /// populate that shelf's members, not just `current_view`, or the
+    /// table renders empty even though the shelf has fics.
+    #[test]
+    fn restart_into_shelf_view_shows_its_fics() {
+        let mut h = given_harness();
+        let fic = fixtures::given_sample_fanfiction(501, "Anchor");
+        fixtures::when_fanfiction_added_to_db(&h.conn, &fic).unwrap();
+        h.app.create_shelf("Favorites").unwrap();
+        let shelf_id = h.app.shelves()[0].id;
+        h.app.add_fic_to_shelf(501, shelf_id).unwrap();
+
+        h.app.open_view(View::Shelf(shelf_id));
+        h.restart(vec!["http://127.0.0.1:1".into()]);
+
+        assert_eq!(*h.app.current_view(), View::Shelf(shelf_id));
+        assert_eq!(h.app.visible_ids(), vec![501]);
+    }
 }

--- a/tests/gui/last_view.rs
+++ b/tests/gui/last_view.rs
@@ -1,0 +1,77 @@
+//! Group G — remembering the last opened tab/shelf across restarts.
+
+#[cfg(test)]
+mod tests {
+    use ficflow::domain::fanfiction::ReadingStatus;
+    use ficflow::interfaces::gui::View;
+
+    use crate::common::fixtures;
+    use crate::harness::GuiHarness;
+
+    fn given_harness() -> GuiHarness {
+        let (conn, db_path, td) = fixtures::given_test_database();
+        GuiHarness::with_db(vec!["http://127.0.0.1:1".into()], conn, db_path, td)
+    }
+
+    /// G1 — switching to a shelf tab and restarting reopens that shelf.
+    #[test]
+    fn restart_reopens_last_shelf_view() {
+        let mut h = given_harness();
+        h.app.create_shelf("Favorites").unwrap();
+        let shelf_id = h.app.shelves()[0].id;
+
+        h.app.open_view(View::Shelf(shelf_id));
+        h.restart(vec!["http://127.0.0.1:1".into()]);
+
+        assert_eq!(*h.app.current_view(), View::Shelf(shelf_id));
+    }
+
+    /// G2 — same for a status tab.
+    #[test]
+    fn restart_reopens_last_status_view() {
+        let mut h = given_harness();
+
+        h.app.open_view(View::ByStatus(ReadingStatus::Read));
+        h.restart(vec!["http://127.0.0.1:1".into()]);
+
+        assert_eq!(*h.app.current_view(), View::ByStatus(ReadingStatus::Read));
+    }
+
+    /// G3 — Tasks/Settings aren't persisted: quitting from one of them
+    /// keeps whatever library tab was open before.
+    #[test]
+    fn tasks_and_settings_are_not_persisted() {
+        let mut h = given_harness();
+        h.app.create_shelf("Favorites").unwrap();
+        let shelf_id = h.app.shelves()[0].id;
+
+        h.app.open_view(View::Shelf(shelf_id));
+        h.app.open_view(View::Settings);
+        h.restart(vec!["http://127.0.0.1:1".into()]);
+
+        assert_eq!(*h.app.current_view(), View::Shelf(shelf_id));
+    }
+
+    /// G4 — if the persisted shelf was deleted in the meantime, startup
+    /// falls back to the all-fics view instead of a dangling reference.
+    #[test]
+    fn restart_falls_back_to_all_fics_when_shelf_was_deleted() {
+        let mut h = given_harness();
+        h.app.create_shelf("Doomed").unwrap();
+        let shelf_id = h.app.shelves()[0].id;
+
+        h.app.open_view(View::Shelf(shelf_id));
+        h.app.delete_shelf(shelf_id).unwrap();
+        h.restart(vec!["http://127.0.0.1:1".into()]);
+
+        assert_eq!(*h.app.current_view(), View::AllFics);
+    }
+
+    /// G5 — with no prior session (fresh config), startup defaults to
+    /// the all-fics view, same as before this feature existed.
+    #[test]
+    fn fresh_config_defaults_to_all_fics() {
+        let h = given_harness();
+        assert_eq!(*h.app.current_view(), View::AllFics);
+    }
+}


### PR DESCRIPTION
## Summary
- Persists the current `View` (AllFics / ByStatus / Shelf) into `AppConfig` and restores it on startup, falling back to `AllFics` if the persisted shelf was deleted since.
- Tasks/Settings aren't persisted — they're transient pages, not library tabs.
- Threads an explicit config file path through `FicflowConfig` so tests write to a scratch file instead of the developer's real `~/.config/ficflow/config.toml`.
- Checks off the corresponding README TODO item.

## Test plan
- [x] `cargo test` — full suite passes (55 GUI tests including 5 new ones in `tests/gui/last_view.rs`, 52 infra tests)
- [x] `cargo clippy --all-targets` — clean
- [x] Manual: run the GUI, switch to a shelf tab, quit, relaunch — same shelf reopens; repeat for a status tab (e.g. "Read")