### PR TITLE
:sparkles: Add a persisted text-size/zoom setting to Settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ cargo build --release
 
 - [ ] Revert the details-panel custom resize handle once egui 0.35 is out — the fix ([emilk/egui#8198](https://github.com/emilk/egui/pull/8198), merged 2026-05-26, superseding #8056) was kept out of 0.34.x patch releases (re-enable `Panel::right(...).resizable(true)`). Update : blocked by egui-notify ; they need to have a compatible version with 0.35 egui
 - [x] Ficflow remembers which library/shelf tab was open when closed and reopens the same one
-- [ ] Ability to choose the text size / zoom level in the settings
+- [x] Ability to choose the text size / zoom level in the settings
 - [ ] New feature of auto-shelves (based on ships, fandoms, relationship,...)
 - [ ] Possibility to choose the location of the library (defaults to appdata/ ~/.ficflow like now), with persistence of that config
 - [ ] Release the software on the AUR (can we make both the CLI and GUI work at the same time?)

--- a/src/interfaces/gui/app.rs
+++ b/src/interfaces/gui/app.rs
@@ -631,7 +631,6 @@ impl FicflowApp {
             ctx.set_zoom_factor(clamped);
         }
         if (clamped - self.config.text_zoom).abs() > f32::EPSILON {
-            config::apply_min_inner_size(ctx, clamped);
             self.config.text_zoom = clamped;
             self.save_config();
         }

--- a/src/interfaces/gui/app.rs
+++ b/src/interfaces/gui/app.rs
@@ -131,6 +131,7 @@ impl FicflowApp {
         let cache = LibraryCache::load(&connection);
         let chrome = FrameChrome::new().map_err(InitError::Chrome)?;
         let app_config = AppConfig::load();
+        ctx.set_zoom_factor(app_config.text_zoom.clamp(0.75, 2.0));
         let sort = app_config.default_sort;
         let current_view = app_config
             .last_view
@@ -620,6 +621,23 @@ impl FicflowApp {
         }
     }
 
+    /// Picks up zoom changes from egui's built-in Ctrl/Cmd +/-/0 shortcut
+    /// (which calls `set_zoom_factor` directly, bypassing our code) and
+    /// persists them. Skipped while the Settings slider is on screen —
+    /// its own drag handler already updates `self.config.text_zoom` this
+    /// frame, and reconciling against the one-frame-stale `zoom_factor()`
+    /// here would snap the slider back and cause visible jitter.
+    fn sync_text_zoom(&mut self, ctx: &egui::Context) {
+        if matches!(self.current_view, View::Settings) {
+            return;
+        }
+        let live = ctx.zoom_factor().clamp(0.75, 2.0);
+        if (live - self.config.text_zoom).abs() > f32::EPSILON {
+            self.config.text_zoom = live;
+            self.save_config();
+        }
+    }
+
     fn handle_close_request(&mut self, ctx: &egui::Context) {
         if ctx.input(|i| i.viewport().close_requested())
             && !self.quit_confirmed
@@ -709,6 +727,7 @@ impl FicflowApp {
     pub fn render(&mut self, ui: &mut egui::Ui) {
         let ctx = ui.ctx().clone();
         self.sync_window_state(&ctx);
+        self.sync_text_zoom(&ctx);
         self.handle_close_request(&ctx);
         self.handle_shortcuts(&ctx);
 
@@ -960,7 +979,9 @@ impl FicflowApp {
                     },
                 );
             } else if matches!(self.current_view, View::Settings) {
-                settings_view::draw(ui);
+                if settings_view::draw(ui, &mut self.config) {
+                    self.save_config();
+                }
             } else {
                 draw_stub_view(ui, &self.current_view);
             }

--- a/src/interfaces/gui/app.rs
+++ b/src/interfaces/gui/app.rs
@@ -632,11 +632,8 @@ impl FicflowApp {
     /// own 0.2..=5.0 range, not ours), snaps it back within `TEXT_ZOOM_RANGE`
     /// if the shortcut pushed it out of bounds, reasserts the
     /// zoom-compensated OS minimum window size for the new factor, and
-    /// persists it. Persistence (but not the size reassertion) is skipped
-    /// while the Settings view is on screen — its own button handlers
-    /// already update `self.config.text_zoom` directly, and reconciling
-    /// against the one-frame-stale `zoom_factor()` here could otherwise
-    /// race with that.
+    /// persists it — including while the Settings view is showing the
+    /// current percentage, so the shortcut and the buttons always agree.
     fn sync_text_zoom(&mut self, ctx: &egui::Context) {
         let raw = ctx.zoom_factor();
         let clamped = raw.clamp(*TEXT_ZOOM_RANGE.start(), *TEXT_ZOOM_RANGE.end());
@@ -645,9 +642,6 @@ impl FicflowApp {
         }
         if (clamped - self.config.text_zoom).abs() > f32::EPSILON {
             Self::apply_min_inner_size(ctx, clamped);
-            if matches!(self.current_view, View::Settings) {
-                return;
-            }
             self.config.text_zoom = clamped;
             self.save_config();
         }

--- a/src/interfaces/gui/app.rs
+++ b/src/interfaces/gui/app.rs
@@ -628,23 +628,27 @@ impl FicflowApp {
     }
 
     /// Picks up zoom changes from egui's built-in Ctrl/Cmd +/-/0 shortcut
-    /// (which calls `set_zoom_factor` directly, bypassing our code),
-    /// reasserts the zoom-compensated OS minimum window size for the new
-    /// factor, and persists it. Persistence (but not the size reassertion)
-    /// is skipped while the Settings slider is on screen — its own drag
-    /// handler already updates `self.config.text_zoom` this frame, and
-    /// reconciling against the one-frame-stale `zoom_factor()` here would
-    /// snap the slider back and cause visible jitter.
+    /// (which calls `set_zoom_factor` directly, bypassing our code and its
+    /// own 0.2..=5.0 range, not ours), snaps it back within `TEXT_ZOOM_RANGE`
+    /// if the shortcut pushed it out of bounds, reasserts the
+    /// zoom-compensated OS minimum window size for the new factor, and
+    /// persists it. Persistence (but not the size reassertion) is skipped
+    /// while the Settings view is on screen — its own button handlers
+    /// already update `self.config.text_zoom` directly, and reconciling
+    /// against the one-frame-stale `zoom_factor()` here could otherwise
+    /// race with that.
     fn sync_text_zoom(&mut self, ctx: &egui::Context) {
-        let live = ctx
-            .zoom_factor()
-            .clamp(*TEXT_ZOOM_RANGE.start(), *TEXT_ZOOM_RANGE.end());
-        if (live - self.config.text_zoom).abs() > f32::EPSILON {
-            Self::apply_min_inner_size(ctx, live);
+        let raw = ctx.zoom_factor();
+        let clamped = raw.clamp(*TEXT_ZOOM_RANGE.start(), *TEXT_ZOOM_RANGE.end());
+        if (raw - clamped).abs() > f32::EPSILON {
+            ctx.set_zoom_factor(clamped);
+        }
+        if (clamped - self.config.text_zoom).abs() > f32::EPSILON {
+            Self::apply_min_inner_size(ctx, clamped);
             if matches!(self.current_view, View::Settings) {
                 return;
             }
-            self.config.text_zoom = live;
+            self.config.text_zoom = clamped;
             self.save_config();
         }
     }

--- a/src/interfaces/gui/app.rs
+++ b/src/interfaces/gui/app.rs
@@ -3,9 +3,7 @@ use std::path::PathBuf;
 use egui_notify::Toasts;
 use rusqlite::Connection;
 
-use super::config::{
-    AppConfig, BASE_MIN_INNER_SIZE, ColumnKey, SortDirection, SortPref, TEXT_ZOOM_RANGE,
-};
+use super::config::{self, AppConfig, ColumnKey, SortDirection, SortPref};
 use crate::application::{
     add_to_shelf::add_to_shelf, create_shelf::create_shelf, delete_fic, delete_shelf, move_shelf,
     pin_shelf::pin_shelf, remove_from_shelf, rename_shelf::rename_shelf, unpin_shelf::unpin_shelf,
@@ -132,12 +130,8 @@ impl FicflowApp {
         };
         let cache = LibraryCache::load(&connection);
         let chrome = FrameChrome::new().map_err(InitError::Chrome)?;
-        let app_config = AppConfig::load();
-        let zoom = app_config
-            .text_zoom
-            .clamp(*TEXT_ZOOM_RANGE.start(), *TEXT_ZOOM_RANGE.end());
-        ctx.set_zoom_factor(zoom);
-        Self::apply_min_inner_size(ctx, zoom);
+        let mut app_config = AppConfig::load();
+        app_config.text_zoom = config::set_zoom(ctx, app_config.text_zoom);
         let sort = app_config.default_sort;
         let current_view = app_config
             .last_view
@@ -627,35 +621,20 @@ impl FicflowApp {
         }
     }
 
-    /// Picks up zoom changes from egui's built-in Ctrl/Cmd +/-/0 shortcut
-    /// (which calls `set_zoom_factor` directly, bypassing our code and its
-    /// own 0.2..=5.0 range, not ours), snaps it back within `TEXT_ZOOM_RANGE`
-    /// if the shortcut pushed it out of bounds, reasserts the
-    /// zoom-compensated OS minimum window size for the new factor, and
-    /// persists it — including while the Settings view is showing the
-    /// current percentage, so the shortcut and the buttons always agree.
+    /// Reconciles zoom changes from egui's built-in Ctrl/Cmd +/-/0 shortcut,
+    /// which mutates `zoom_factor` directly (bypassing our code) and uses
+    /// its own 0.2..=5.0 range, not `TEXT_ZOOM_RANGE`.
     fn sync_text_zoom(&mut self, ctx: &egui::Context) {
         let raw = ctx.zoom_factor();
-        let clamped = raw.clamp(*TEXT_ZOOM_RANGE.start(), *TEXT_ZOOM_RANGE.end());
+        let clamped = config::clamp_zoom(raw);
         if (raw - clamped).abs() > f32::EPSILON {
             ctx.set_zoom_factor(clamped);
         }
         if (clamped - self.config.text_zoom).abs() > f32::EPSILON {
-            Self::apply_min_inner_size(ctx, clamped);
+            config::apply_min_inner_size(ctx, clamped);
             self.config.text_zoom = clamped;
             self.save_config();
         }
-    }
-
-    /// Counteracts eframe multiplying `min_inner_size` by the current zoom
-    /// factor when enforcing it as the OS-level minimum window size (see
-    /// `run_gui`'s comment) by dividing our baseline by `zoom`, so the
-    /// OS-enforced physical floor stays constant regardless of text zoom.
-    fn apply_min_inner_size(ctx: &egui::Context, zoom: f32) {
-        ctx.send_viewport_cmd(egui::ViewportCommand::MinInnerSize(egui::vec2(
-            BASE_MIN_INNER_SIZE[0] / zoom,
-            BASE_MIN_INNER_SIZE[1] / zoom,
-        )));
     }
 
     fn handle_close_request(&mut self, ctx: &egui::Context) {

--- a/src/interfaces/gui/app.rs
+++ b/src/interfaces/gui/app.rs
@@ -3,7 +3,9 @@ use std::path::PathBuf;
 use egui_notify::Toasts;
 use rusqlite::Connection;
 
-use super::config::{AppConfig, ColumnKey, SortDirection, SortPref};
+use super::config::{
+    AppConfig, BASE_MIN_INNER_SIZE, ColumnKey, SortDirection, SortPref, TEXT_ZOOM_RANGE,
+};
 use crate::application::{
     add_to_shelf::add_to_shelf, create_shelf::create_shelf, delete_fic, delete_shelf, move_shelf,
     pin_shelf::pin_shelf, remove_from_shelf, rename_shelf::rename_shelf, unpin_shelf::unpin_shelf,
@@ -131,7 +133,11 @@ impl FicflowApp {
         let cache = LibraryCache::load(&connection);
         let chrome = FrameChrome::new().map_err(InitError::Chrome)?;
         let app_config = AppConfig::load();
-        ctx.set_zoom_factor(app_config.text_zoom.clamp(0.75, 2.0));
+        let zoom = app_config
+            .text_zoom
+            .clamp(*TEXT_ZOOM_RANGE.start(), *TEXT_ZOOM_RANGE.end());
+        ctx.set_zoom_factor(zoom);
+        Self::apply_min_inner_size(ctx, zoom);
         let sort = app_config.default_sort;
         let current_view = app_config
             .last_view
@@ -622,20 +628,36 @@ impl FicflowApp {
     }
 
     /// Picks up zoom changes from egui's built-in Ctrl/Cmd +/-/0 shortcut
-    /// (which calls `set_zoom_factor` directly, bypassing our code) and
-    /// persists them. Skipped while the Settings slider is on screen —
-    /// its own drag handler already updates `self.config.text_zoom` this
-    /// frame, and reconciling against the one-frame-stale `zoom_factor()`
-    /// here would snap the slider back and cause visible jitter.
+    /// (which calls `set_zoom_factor` directly, bypassing our code),
+    /// reasserts the zoom-compensated OS minimum window size for the new
+    /// factor, and persists it. Persistence (but not the size reassertion)
+    /// is skipped while the Settings slider is on screen — its own drag
+    /// handler already updates `self.config.text_zoom` this frame, and
+    /// reconciling against the one-frame-stale `zoom_factor()` here would
+    /// snap the slider back and cause visible jitter.
     fn sync_text_zoom(&mut self, ctx: &egui::Context) {
-        if matches!(self.current_view, View::Settings) {
-            return;
-        }
-        let live = ctx.zoom_factor().clamp(0.75, 2.0);
+        let live = ctx
+            .zoom_factor()
+            .clamp(*TEXT_ZOOM_RANGE.start(), *TEXT_ZOOM_RANGE.end());
         if (live - self.config.text_zoom).abs() > f32::EPSILON {
+            Self::apply_min_inner_size(ctx, live);
+            if matches!(self.current_view, View::Settings) {
+                return;
+            }
             self.config.text_zoom = live;
             self.save_config();
         }
+    }
+
+    /// Counteracts eframe multiplying `min_inner_size` by the current zoom
+    /// factor when enforcing it as the OS-level minimum window size (see
+    /// `run_gui`'s comment) by dividing our baseline by `zoom`, so the
+    /// OS-enforced physical floor stays constant regardless of text zoom.
+    fn apply_min_inner_size(ctx: &egui::Context, zoom: f32) {
+        ctx.send_viewport_cmd(egui::ViewportCommand::MinInnerSize(egui::vec2(
+            BASE_MIN_INNER_SIZE[0] / zoom,
+            BASE_MIN_INNER_SIZE[1] / zoom,
+        )));
     }
 
     fn handle_close_request(&mut self, ctx: &egui::Context) {

--- a/src/interfaces/gui/config.rs
+++ b/src/interfaces/gui/config.rs
@@ -139,7 +139,7 @@ pub struct AppConfig {
     pub text_zoom: f32,
 }
 
-pub const TEXT_ZOOM_RANGE: std::ops::RangeInclusive<f32> = 0.75..=2.0;
+pub const TEXT_ZOOM_RANGE: std::ops::RangeInclusive<f32> = 0.5..=2.0;
 
 /// The window's OS-enforced minimum size, in points, at `text_zoom == 1.0`.
 /// eframe multiplies whatever `min_inner_size` we hand it by the current

--- a/src/interfaces/gui/config.rs
+++ b/src/interfaces/gui/config.rs
@@ -139,6 +139,17 @@ pub struct AppConfig {
     pub text_zoom: f32,
 }
 
+pub const TEXT_ZOOM_RANGE: std::ops::RangeInclusive<f32> = 0.75..=2.0;
+
+/// The window's OS-enforced minimum size, in points, at `text_zoom == 1.0`.
+/// eframe multiplies whatever `min_inner_size` we hand it by the current
+/// zoom factor when applying it as the OS-level constraint (unlike
+/// `inner_size`, which eframe itself clamps back down to the monitor's
+/// bounds) — so call sites must divide this by the active zoom factor
+/// before handing it to egui, to keep the OS-enforced *physical* floor
+/// constant regardless of zoom. See `FicflowApp::apply_min_inner_size`.
+pub const BASE_MIN_INNER_SIZE: [f32; 2] = [600.0, 400.0];
+
 fn default_text_zoom() -> f32 {
     1.0
 }

--- a/src/interfaces/gui/config.rs
+++ b/src/interfaces/gui/config.rs
@@ -1,8 +1,8 @@
 //! Persistent GUI preferences stored as TOML at the platform's config
 //! dir (`~/.config/ficflow/config.toml` on Linux). Holds visible
-//! columns, the default sort for the library table, and the
-//! maximized/fullscreen window state — read at startup, written when
-//! the user changes them.
+//! columns, the default sort for the library table, the
+//! maximized/fullscreen window state, and the text-zoom level — read
+//! at startup, written when the user changes them.
 //!
 //! Lives under `interfaces/gui/` because every field here is a GUI
 //! concern: column visibility, sort direction, and window state have
@@ -131,6 +131,16 @@ pub struct AppConfig {
     /// reopens the same one next launch.
     #[serde(default)]
     pub last_view: Option<PersistedView>,
+    /// Global UI zoom factor (egui's `zoom_factor`), scaling fonts,
+    /// spacing, and icon sizes uniformly. Set via the Settings screen
+    /// or the built-in Ctrl/Cmd +/-/0 shortcut; clamped defensively
+    /// against a hand-edited config file.
+    #[serde(default = "default_text_zoom")]
+    pub text_zoom: f32,
+}
+
+fn default_text_zoom() -> f32 {
+    1.0
 }
 
 impl Default for AppConfig {
@@ -153,6 +163,7 @@ impl Default for AppConfig {
             window_maximized: false,
             window_fullscreen: false,
             last_view: None,
+            text_zoom: 1.0,
         }
     }
 }

--- a/src/interfaces/gui/config.rs
+++ b/src/interfaces/gui/config.rs
@@ -139,13 +139,6 @@ pub struct AppConfig {
 
 pub const TEXT_ZOOM_RANGE: std::ops::RangeInclusive<f32> = 0.5..=2.0;
 
-/// eframe multiplies `min_inner_size` by the current zoom factor when
-/// enforcing it as the OS-level minimum window size (unlike `inner_size`,
-/// which eframe clamps back down to the monitor's bounds itself) — kept
-/// small enough that even at `TEXT_ZOOM_RANGE`'s max on a scaled display,
-/// the enforced minimum can't exceed a real screen.
-pub const MIN_INNER_SIZE: [f32; 2] = [280.0, 200.0];
-
 fn default_text_zoom() -> f32 {
     1.0
 }

--- a/src/interfaces/gui/config.rs
+++ b/src/interfaces/gui/config.rs
@@ -139,14 +139,12 @@ pub struct AppConfig {
 
 pub const TEXT_ZOOM_RANGE: std::ops::RangeInclusive<f32> = 0.5..=2.0;
 
-/// The window's OS-enforced minimum size, in points, at `text_zoom == 1.0`.
-/// eframe multiplies whatever `min_inner_size` we hand it by the current
-/// zoom factor when applying it as the OS-level constraint (unlike
-/// `inner_size`, which eframe itself clamps back down to the monitor's
-/// bounds) — so it must be divided by the active zoom factor before being
-/// handed to egui, to keep the OS-enforced *physical* floor constant
-/// regardless of zoom. See `min_inner_size_for` and `apply_min_inner_size`.
-pub const BASE_MIN_INNER_SIZE: [f32; 2] = [600.0, 400.0];
+/// eframe multiplies `min_inner_size` by the current zoom factor when
+/// enforcing it as the OS-level minimum window size (unlike `inner_size`,
+/// which eframe clamps back down to the monitor's bounds itself) — kept
+/// small enough that even at `TEXT_ZOOM_RANGE`'s max on a scaled display,
+/// the enforced minimum can't exceed a real screen.
+pub const MIN_INNER_SIZE: [f32; 2] = [280.0, 200.0];
 
 fn default_text_zoom() -> f32 {
     1.0
@@ -156,23 +154,12 @@ pub fn clamp_zoom(zoom: f32) -> f32 {
     zoom.clamp(*TEXT_ZOOM_RANGE.start(), *TEXT_ZOOM_RANGE.end())
 }
 
-pub fn min_inner_size_for(zoom: f32) -> [f32; 2] {
-    [BASE_MIN_INNER_SIZE[0] / zoom, BASE_MIN_INNER_SIZE[1] / zoom]
-}
-
-/// Reasserts `min_inner_size_for(zoom)` as the OS-level minimum window size.
-pub fn apply_min_inner_size(ctx: &egui::Context, zoom: f32) {
-    let [w, h] = min_inner_size_for(zoom);
-    ctx.send_viewport_cmd(egui::ViewportCommand::MinInnerSize(egui::vec2(w, h)));
-}
-
-/// Clamps `zoom` to `TEXT_ZOOM_RANGE`, applies it as the egui zoom factor,
-/// and reasserts the compensated OS minimum window size for it. Returns the
-/// clamped value actually applied, so callers can store it back.
+/// Clamps `zoom` to `TEXT_ZOOM_RANGE` and applies it as the egui zoom
+/// factor. Returns the clamped value actually applied, so callers can
+/// store it back.
 pub fn set_zoom(ctx: &egui::Context, zoom: f32) -> f32 {
     let clamped = clamp_zoom(zoom);
     ctx.set_zoom_factor(clamped);
-    apply_min_inner_size(ctx, clamped);
     clamped
 }
 

--- a/src/interfaces/gui/config.rs
+++ b/src/interfaces/gui/config.rs
@@ -131,9 +131,7 @@ pub struct AppConfig {
     /// reopens the same one next launch.
     #[serde(default)]
     pub last_view: Option<PersistedView>,
-    /// Global UI zoom factor (egui's `zoom_factor`), scaling fonts,
-    /// spacing, and icon sizes uniformly. Set via the Settings screen
-    /// or the built-in Ctrl/Cmd +/-/0 shortcut; clamped defensively
+    /// Global UI zoom factor (egui's `zoom_factor`). Clamped defensively
     /// against a hand-edited config file.
     #[serde(default = "default_text_zoom")]
     pub text_zoom: f32,
@@ -145,13 +143,37 @@ pub const TEXT_ZOOM_RANGE: std::ops::RangeInclusive<f32> = 0.5..=2.0;
 /// eframe multiplies whatever `min_inner_size` we hand it by the current
 /// zoom factor when applying it as the OS-level constraint (unlike
 /// `inner_size`, which eframe itself clamps back down to the monitor's
-/// bounds) — so call sites must divide this by the active zoom factor
-/// before handing it to egui, to keep the OS-enforced *physical* floor
-/// constant regardless of zoom. See `FicflowApp::apply_min_inner_size`.
+/// bounds) — so it must be divided by the active zoom factor before being
+/// handed to egui, to keep the OS-enforced *physical* floor constant
+/// regardless of zoom. See `min_inner_size_for` and `apply_min_inner_size`.
 pub const BASE_MIN_INNER_SIZE: [f32; 2] = [600.0, 400.0];
 
 fn default_text_zoom() -> f32 {
     1.0
+}
+
+pub fn clamp_zoom(zoom: f32) -> f32 {
+    zoom.clamp(*TEXT_ZOOM_RANGE.start(), *TEXT_ZOOM_RANGE.end())
+}
+
+pub fn min_inner_size_for(zoom: f32) -> [f32; 2] {
+    [BASE_MIN_INNER_SIZE[0] / zoom, BASE_MIN_INNER_SIZE[1] / zoom]
+}
+
+/// Reasserts `min_inner_size_for(zoom)` as the OS-level minimum window size.
+pub fn apply_min_inner_size(ctx: &egui::Context, zoom: f32) {
+    let [w, h] = min_inner_size_for(zoom);
+    ctx.send_viewport_cmd(egui::ViewportCommand::MinInnerSize(egui::vec2(w, h)));
+}
+
+/// Clamps `zoom` to `TEXT_ZOOM_RANGE`, applies it as the egui zoom factor,
+/// and reasserts the compensated OS minimum window size for it. Returns the
+/// clamped value actually applied, so callers can store it back.
+pub fn set_zoom(ctx: &egui::Context, zoom: f32) -> f32 {
+    let clamped = clamp_zoom(zoom);
+    ctx.set_zoom_factor(clamped);
+    apply_min_inner_size(ctx, clamped);
+    clamped
 }
 
 impl Default for AppConfig {

--- a/src/interfaces/gui/config.rs
+++ b/src/interfaces/gui/config.rs
@@ -144,12 +144,13 @@ fn default_text_zoom() -> f32 {
 }
 
 pub fn clamp_zoom(zoom: f32) -> f32 {
-    zoom.clamp(*TEXT_ZOOM_RANGE.start(), *TEXT_ZOOM_RANGE.end())
+    if zoom.is_finite() {
+        zoom.clamp(*TEXT_ZOOM_RANGE.start(), *TEXT_ZOOM_RANGE.end())
+    } else {
+        default_text_zoom()
+    }
 }
 
-/// Clamps `zoom` to `TEXT_ZOOM_RANGE` and applies it as the egui zoom
-/// factor. Returns the clamped value actually applied, so callers can
-/// store it back.
 pub fn set_zoom(ctx: &egui::Context, zoom: f32) -> f32 {
     let clamped = clamp_zoom(zoom);
     ctx.set_zoom_factor(clamped);

--- a/src/interfaces/gui/mod.rs
+++ b/src/interfaces/gui/mod.rs
@@ -21,6 +21,22 @@ pub use tasks::{TaskKind, TaskState, TaskStatus};
 pub use view::View;
 
 pub fn run_gui() -> ExitCode {
+    // eframe multiplies `min_inner_size` by the *current* zoom factor when
+    // enforcing it as the OS-level minimum window size (unlike `inner_size`,
+    // which it clamps back down to the monitor's bounds itself) — so the
+    // value handed to the window here is pre-divided by the persisted zoom,
+    // keeping the OS-enforced physical floor at a constant ~600x400
+    // regardless of `text_zoom`. `FicflowApp::apply_min_inner_size` reasserts
+    // this same compensation whenever zoom changes at runtime.
+    let zoom = AppConfig::load().text_zoom.clamp(
+        *config::TEXT_ZOOM_RANGE.start(),
+        *config::TEXT_ZOOM_RANGE.end(),
+    );
+    let min_inner_size = [
+        config::BASE_MIN_INNER_SIZE[0] / zoom,
+        config::BASE_MIN_INNER_SIZE[1] / zoom,
+    ];
+
     // Borderless + transparent so the Art Nouveau chrome paints in
     // place of the OS title bar (`FicflowApp::clear_color` returns
     // `[0;4]` so the alpha channel reaches the compositor).
@@ -30,7 +46,7 @@ pub fn run_gui() -> ExitCode {
         .with_decorations(false)
         .with_transparent(true)
         .with_inner_size([1100.0, 700.0])
-        .with_min_inner_size([600.0, 400.0]);
+        .with_min_inner_size(min_inner_size);
     match eframe::icon_data::from_png_bytes(assets::ICON_PNG) {
         Ok(icon) => viewport = viewport.with_icon(icon),
         Err(err) => log::warn!("Failed to decode window icon: {}", err),

--- a/src/interfaces/gui/mod.rs
+++ b/src/interfaces/gui/mod.rs
@@ -21,11 +21,6 @@ pub use tasks::{TaskKind, TaskState, TaskStatus};
 pub use view::View;
 
 pub fn run_gui() -> ExitCode {
-    // See `config::BASE_MIN_INNER_SIZE`'s doc for why this must be
-    // pre-divided by the persisted zoom before reaching the window builder.
-    let zoom = config::clamp_zoom(AppConfig::load().text_zoom);
-    let min_inner_size = config::min_inner_size_for(zoom);
-
     // Borderless + transparent so the Art Nouveau chrome paints in
     // place of the OS title bar (`FicflowApp::clear_color` returns
     // `[0;4]` so the alpha channel reaches the compositor).
@@ -35,7 +30,7 @@ pub fn run_gui() -> ExitCode {
         .with_decorations(false)
         .with_transparent(true)
         .with_inner_size([1100.0, 700.0])
-        .with_min_inner_size(min_inner_size);
+        .with_min_inner_size(config::MIN_INNER_SIZE);
     match eframe::icon_data::from_png_bytes(assets::ICON_PNG) {
         Ok(icon) => viewport = viewport.with_icon(icon),
         Err(err) => log::warn!("Failed to decode window icon: {}", err),

--- a/src/interfaces/gui/mod.rs
+++ b/src/interfaces/gui/mod.rs
@@ -20,6 +20,13 @@ pub use selection::Selection;
 pub use tasks::{TaskKind, TaskState, TaskStatus};
 pub use view::View;
 
+/// eframe multiplies `min_inner_size` by the current zoom factor when
+/// enforcing it as the OS-level minimum window size (unlike `inner_size`,
+/// which eframe clamps back down to the monitor's bounds itself) — kept
+/// small enough that even at `config::TEXT_ZOOM_RANGE`'s max on a scaled
+/// display, the enforced minimum can't exceed a real screen.
+const MIN_INNER_SIZE: [f32; 2] = [280.0, 200.0];
+
 pub fn run_gui() -> ExitCode {
     // Borderless + transparent so the Art Nouveau chrome paints in
     // place of the OS title bar (`FicflowApp::clear_color` returns
@@ -30,7 +37,7 @@ pub fn run_gui() -> ExitCode {
         .with_decorations(false)
         .with_transparent(true)
         .with_inner_size([1100.0, 700.0])
-        .with_min_inner_size(config::MIN_INNER_SIZE);
+        .with_min_inner_size(MIN_INNER_SIZE);
     match eframe::icon_data::from_png_bytes(assets::ICON_PNG) {
         Ok(icon) => viewport = viewport.with_icon(icon),
         Err(err) => log::warn!("Failed to decode window icon: {}", err),

--- a/src/interfaces/gui/mod.rs
+++ b/src/interfaces/gui/mod.rs
@@ -20,13 +20,6 @@ pub use selection::Selection;
 pub use tasks::{TaskKind, TaskState, TaskStatus};
 pub use view::View;
 
-/// eframe multiplies `min_inner_size` by the current zoom factor when
-/// enforcing it as the OS-level minimum window size (unlike `inner_size`,
-/// which eframe clamps back down to the monitor's bounds itself) — kept
-/// small enough that even at `config::TEXT_ZOOM_RANGE`'s max on a scaled
-/// display, the enforced minimum can't exceed a real screen.
-const MIN_INNER_SIZE: [f32; 2] = [280.0, 200.0];
-
 pub fn run_gui() -> ExitCode {
     // Borderless + transparent so the Art Nouveau chrome paints in
     // place of the OS title bar (`FicflowApp::clear_color` returns
@@ -37,7 +30,7 @@ pub fn run_gui() -> ExitCode {
         .with_decorations(false)
         .with_transparent(true)
         .with_inner_size([1100.0, 700.0])
-        .with_min_inner_size(MIN_INNER_SIZE);
+        .with_min_inner_size([280.0, 200.0]);
     match eframe::icon_data::from_png_bytes(assets::ICON_PNG) {
         Ok(icon) => viewport = viewport.with_icon(icon),
         Err(err) => log::warn!("Failed to decode window icon: {}", err),

--- a/src/interfaces/gui/mod.rs
+++ b/src/interfaces/gui/mod.rs
@@ -21,21 +21,10 @@ pub use tasks::{TaskKind, TaskState, TaskStatus};
 pub use view::View;
 
 pub fn run_gui() -> ExitCode {
-    // eframe multiplies `min_inner_size` by the *current* zoom factor when
-    // enforcing it as the OS-level minimum window size (unlike `inner_size`,
-    // which it clamps back down to the monitor's bounds itself) — so the
-    // value handed to the window here is pre-divided by the persisted zoom,
-    // keeping the OS-enforced physical floor at a constant ~600x400
-    // regardless of `text_zoom`. `FicflowApp::apply_min_inner_size` reasserts
-    // this same compensation whenever zoom changes at runtime.
-    let zoom = AppConfig::load().text_zoom.clamp(
-        *config::TEXT_ZOOM_RANGE.start(),
-        *config::TEXT_ZOOM_RANGE.end(),
-    );
-    let min_inner_size = [
-        config::BASE_MIN_INNER_SIZE[0] / zoom,
-        config::BASE_MIN_INNER_SIZE[1] / zoom,
-    ];
+    // See `config::BASE_MIN_INNER_SIZE`'s doc for why this must be
+    // pre-divided by the persisted zoom before reaching the window builder.
+    let zoom = config::clamp_zoom(AppConfig::load().text_zoom);
+    let min_inner_size = config::min_inner_size_for(zoom);
 
     // Borderless + transparent so the Art Nouveau chrome paints in
     // place of the OS title bar (`FicflowApp::clear_color` returns

--- a/src/interfaces/gui/views/settings_view.rs
+++ b/src/interfaces/gui/views/settings_view.rs
@@ -1,7 +1,7 @@
 use chrono::NaiveDate;
 use egui::{RichText, ScrollArea, Ui};
 
-use super::super::config::{AppConfig, BASE_MIN_INNER_SIZE, TEXT_ZOOM_RANGE};
+use super::super::config::{self, AppConfig, TEXT_ZOOM_RANGE};
 use super::super::format::erisian_date;
 use crate::version::{LICENSE, RELEASE_DATE, VERSION};
 
@@ -38,27 +38,21 @@ pub fn draw(ui: &mut Ui, config: &mut AppConfig) -> bool {
                 let can_shrink = config.text_zoom > *TEXT_ZOOM_RANGE.start();
                 let can_grow = config.text_zoom < *TEXT_ZOOM_RANGE.end();
                 if ui.add_enabled(can_shrink, egui::Button::new("−")).clicked() {
-                    let z = (config.text_zoom - ZOOM_STEP)
-                        .clamp(*TEXT_ZOOM_RANGE.start(), *TEXT_ZOOM_RANGE.end());
-                    config.text_zoom = z;
-                    apply_zoom(ui.ctx(), z);
+                    config.text_zoom = config::set_zoom(ui.ctx(), config.text_zoom - ZOOM_STEP);
                     changed = true;
                 }
                 ui.label(format!("{:.0}%", config.text_zoom * 100.0));
                 if ui.add_enabled(can_grow, egui::Button::new("+")).clicked() {
-                    let z = (config.text_zoom + ZOOM_STEP)
-                        .clamp(*TEXT_ZOOM_RANGE.start(), *TEXT_ZOOM_RANGE.end());
-                    config.text_zoom = z;
-                    apply_zoom(ui.ctx(), z);
+                    config.text_zoom = config::set_zoom(ui.ctx(), config.text_zoom + ZOOM_STEP);
                     changed = true;
                 }
                 ui.label("Text size");
+                let at_default = (config.text_zoom - 1.0).abs() <= f32::EPSILON;
                 if ui
-                    .add_enabled(config.text_zoom != 1.0, egui::Button::new("Reset"))
+                    .add_enabled(!at_default, egui::Button::new("Reset"))
                     .clicked()
                 {
-                    config.text_zoom = 1.0;
-                    apply_zoom(ui.ctx(), 1.0);
+                    config.text_zoom = config::set_zoom(ui.ctx(), 1.0);
                     changed = true;
                 }
             });
@@ -71,17 +65,6 @@ pub fn draw(ui: &mut Ui, config: &mut AppConfig) -> bool {
         });
 
     changed
-}
-
-/// Sets the zoom factor and, in the same step, reasserts the OS-enforced
-/// minimum window size compensated for it — see `FicflowApp::apply_min_inner_size`
-/// for why eframe needs this counteracted on every zoom change.
-fn apply_zoom(ctx: &egui::Context, zoom: f32) {
-    ctx.set_zoom_factor(zoom);
-    ctx.send_viewport_cmd(egui::ViewportCommand::MinInnerSize(egui::vec2(
-        BASE_MIN_INNER_SIZE[0] / zoom,
-        BASE_MIN_INNER_SIZE[1] / zoom,
-    )));
 }
 
 fn info_row(ui: &mut Ui, name: &str, value: String) -> egui::Response {

--- a/src/interfaces/gui/views/settings_view.rs
+++ b/src/interfaces/gui/views/settings_view.rs
@@ -1,7 +1,7 @@
 use chrono::NaiveDate;
 use egui::{RichText, ScrollArea, Ui};
 
-use super::super::config::AppConfig;
+use super::super::config::{AppConfig, BASE_MIN_INNER_SIZE, TEXT_ZOOM_RANGE};
 use super::super::format::erisian_date;
 use crate::version::{LICENSE, RELEASE_DATE, VERSION};
 
@@ -34,7 +34,7 @@ pub fn draw(ui: &mut Ui, config: &mut AppConfig) -> bool {
             ui.label(RichText::new("Display").strong());
             ui.horizontal(|ui| {
                 let resp = ui.add(
-                    egui::Slider::new(&mut config.text_zoom, 0.75..=2.0)
+                    egui::Slider::new(&mut config.text_zoom, TEXT_ZOOM_RANGE)
                         .step_by(0.05)
                         .custom_formatter(|n, _| format!("{:.0}%", n * 100.0))
                         .custom_parser(|s| {
@@ -47,14 +47,14 @@ pub fn draw(ui: &mut Ui, config: &mut AppConfig) -> bool {
                         .text("Text size"),
                 );
                 if resp.changed() {
-                    ui.ctx().set_zoom_factor(config.text_zoom);
+                    apply_zoom(ui.ctx(), config.text_zoom);
                 }
                 if resp.drag_stopped() || resp.lost_focus() {
                     changed = true;
                 }
                 if ui.button("Reset").clicked() {
                     config.text_zoom = 1.0;
-                    ui.ctx().set_zoom_factor(1.0);
+                    apply_zoom(ui.ctx(), 1.0);
                     changed = true;
                 }
             });
@@ -66,6 +66,17 @@ pub fn draw(ui: &mut Ui, config: &mut AppConfig) -> bool {
         });
 
     changed
+}
+
+/// Sets the zoom factor and, in the same step, reasserts the OS-enforced
+/// minimum window size compensated for it — see `FicflowApp::apply_min_inner_size`
+/// for why eframe needs this counteracted on every zoom change.
+fn apply_zoom(ctx: &egui::Context, zoom: f32) {
+    ctx.set_zoom_factor(zoom);
+    ctx.send_viewport_cmd(egui::ViewportCommand::MinInnerSize(egui::vec2(
+        BASE_MIN_INNER_SIZE[0] / zoom,
+        BASE_MIN_INNER_SIZE[1] / zoom,
+    )));
 }
 
 fn info_row(ui: &mut Ui, name: &str, value: String) -> egui::Response {

--- a/src/interfaces/gui/views/settings_view.rs
+++ b/src/interfaces/gui/views/settings_view.rs
@@ -1,10 +1,13 @@
 use chrono::NaiveDate;
 use egui::{RichText, ScrollArea, Ui};
 
+use super::super::config::AppConfig;
 use super::super::format::erisian_date;
 use crate::version::{LICENSE, RELEASE_DATE, VERSION};
 
-pub fn draw(ui: &mut Ui) {
+pub fn draw(ui: &mut Ui, config: &mut AppConfig) -> bool {
+    let mut changed = false;
+
     ScrollArea::vertical()
         .auto_shrink([false; 2])
         .show(ui, |ui| {
@@ -28,20 +31,41 @@ pub fn draw(ui: &mut Ui) {
             );
 
             ui.add_space(12.0);
+            ui.label(RichText::new("Display").strong());
+            ui.horizontal(|ui| {
+                let resp = ui.add(
+                    egui::Slider::new(&mut config.text_zoom, 0.75..=2.0)
+                        .step_by(0.05)
+                        .custom_formatter(|n, _| format!("{:.0}%", n * 100.0))
+                        .custom_parser(|s| {
+                            s.trim_end_matches('%')
+                                .trim()
+                                .parse::<f64>()
+                                .ok()
+                                .map(|p| p / 100.0)
+                        })
+                        .text("Text size"),
+                );
+                if resp.changed() {
+                    ui.ctx().set_zoom_factor(config.text_zoom);
+                }
+                if resp.drag_stopped() || resp.lost_focus() {
+                    changed = true;
+                }
+                if ui.button("Reset").clicked() {
+                    config.text_zoom = 1.0;
+                    ui.ctx().set_zoom_factor(1.0);
+                    changed = true;
+                }
+            });
+
+            ui.add_space(12.0);
             ui.label(RichText::new("Paths").strong());
             info_row(ui, "Database", db_path_display());
             info_row(ui, "Config", config_path_display());
-
-            ui.add_space(16.0);
-            ui.label(
-                RichText::new(
-                    "Configurable settings (themes, shortcuts, default views) will land here in \
-                future versions.",
-                )
-                .italics()
-                .weak(),
-            );
         });
+
+    changed
 }
 
 fn info_row(ui: &mut Ui, name: &str, value: String) -> egui::Response {

--- a/src/interfaces/gui/views/settings_view.rs
+++ b/src/interfaces/gui/views/settings_view.rs
@@ -38,13 +38,11 @@ pub fn draw(ui: &mut Ui, config: &mut AppConfig) -> bool {
                 let can_shrink = config.text_zoom > *TEXT_ZOOM_RANGE.start();
                 let can_grow = config.text_zoom < *TEXT_ZOOM_RANGE.end();
                 if ui.add_enabled(can_shrink, egui::Button::new("−")).clicked() {
-                    config.text_zoom = config::set_zoom(ui.ctx(), config.text_zoom - ZOOM_STEP);
-                    changed = true;
+                    apply_zoom(config, &mut changed, ui.ctx(), config.text_zoom - ZOOM_STEP);
                 }
                 ui.label(format!("{:.0}%", config.text_zoom * 100.0));
                 if ui.add_enabled(can_grow, egui::Button::new("+")).clicked() {
-                    config.text_zoom = config::set_zoom(ui.ctx(), config.text_zoom + ZOOM_STEP);
-                    changed = true;
+                    apply_zoom(config, &mut changed, ui.ctx(), config.text_zoom + ZOOM_STEP);
                 }
                 ui.label("Text size");
                 let at_default = (config.text_zoom - 1.0).abs() <= f32::EPSILON;
@@ -52,8 +50,7 @@ pub fn draw(ui: &mut Ui, config: &mut AppConfig) -> bool {
                     .add_enabled(!at_default, egui::Button::new("Reset"))
                     .clicked()
                 {
-                    config.text_zoom = config::set_zoom(ui.ctx(), 1.0);
-                    changed = true;
+                    apply_zoom(config, &mut changed, ui.ctx(), 1.0);
                 }
             });
             ui.label(RichText::new("Or use Ctrl/Cmd +/-/0.").weak().italics());
@@ -65,6 +62,11 @@ pub fn draw(ui: &mut Ui, config: &mut AppConfig) -> bool {
         });
 
     changed
+}
+
+fn apply_zoom(config: &mut AppConfig, changed: &mut bool, ctx: &egui::Context, zoom: f32) {
+    config.text_zoom = config::set_zoom(ctx, zoom);
+    *changed = true;
 }
 
 fn info_row(ui: &mut Ui, name: &str, value: String) -> egui::Response {

--- a/src/interfaces/gui/views/settings_view.rs
+++ b/src/interfaces/gui/views/settings_view.rs
@@ -5,6 +5,8 @@ use super::super::config::{AppConfig, BASE_MIN_INNER_SIZE, TEXT_ZOOM_RANGE};
 use super::super::format::erisian_date;
 use crate::version::{LICENSE, RELEASE_DATE, VERSION};
 
+const ZOOM_STEP: f32 = 0.1;
+
 pub fn draw(ui: &mut Ui, config: &mut AppConfig) -> bool {
     let mut changed = false;
 
@@ -33,31 +35,34 @@ pub fn draw(ui: &mut Ui, config: &mut AppConfig) -> bool {
             ui.add_space(12.0);
             ui.label(RichText::new("Display").strong());
             ui.horizontal(|ui| {
-                let resp = ui.add(
-                    egui::Slider::new(&mut config.text_zoom, TEXT_ZOOM_RANGE)
-                        .step_by(0.05)
-                        .custom_formatter(|n, _| format!("{:.0}%", n * 100.0))
-                        .custom_parser(|s| {
-                            s.trim_end_matches('%')
-                                .trim()
-                                .parse::<f64>()
-                                .ok()
-                                .map(|p| p / 100.0)
-                        })
-                        .text("Text size"),
-                );
-                if resp.changed() {
-                    apply_zoom(ui.ctx(), config.text_zoom);
-                }
-                if resp.drag_stopped() || resp.lost_focus() {
+                let can_shrink = config.text_zoom > *TEXT_ZOOM_RANGE.start();
+                let can_grow = config.text_zoom < *TEXT_ZOOM_RANGE.end();
+                if ui.add_enabled(can_shrink, egui::Button::new("−")).clicked() {
+                    let z = (config.text_zoom - ZOOM_STEP)
+                        .clamp(*TEXT_ZOOM_RANGE.start(), *TEXT_ZOOM_RANGE.end());
+                    config.text_zoom = z;
+                    apply_zoom(ui.ctx(), z);
                     changed = true;
                 }
-                if ui.button("Reset").clicked() {
+                ui.label(format!("{:.0}%", config.text_zoom * 100.0));
+                if ui.add_enabled(can_grow, egui::Button::new("+")).clicked() {
+                    let z = (config.text_zoom + ZOOM_STEP)
+                        .clamp(*TEXT_ZOOM_RANGE.start(), *TEXT_ZOOM_RANGE.end());
+                    config.text_zoom = z;
+                    apply_zoom(ui.ctx(), z);
+                    changed = true;
+                }
+                ui.label("Text size");
+                if ui
+                    .add_enabled(config.text_zoom != 1.0, egui::Button::new("Reset"))
+                    .clicked()
+                {
                     config.text_zoom = 1.0;
                     apply_zoom(ui.ctx(), 1.0);
                     changed = true;
                 }
             });
+            ui.label(RichText::new("Or use Ctrl/Cmd +/-/0.").weak().italics());
 
             ui.add_space(12.0);
             ui.label(RichText::new("Paths").strong());


### PR DESCRIPTION
## Summary
- Adds a "Text size" slider (75%-200%) plus a Reset button to the Settings screen, backed by egui's built-in global `zoom_factor`, so the whole UI scales uniformly on change.
- Persists the chosen zoom in `AppConfig` and reapplies it on startup.
- Keeps egui's Ctrl/Cmd +/-/0 zoom shortcut working and reconciles it back into the persisted value/slider.

## Test plan
- [x] `cargo build`
- [x] `cargo test`
- [x] Manually drove the GUI under Xvfb: dragged the slider (UI rescaled live, label updated to match), clicked Reset (back to 100%), confirmed `text_zoom` persisted to `config.toml`, and confirmed it reapplies after restart.