### PR TITLE
:bug: Fix Windows console window and auto-shelf gear glyph

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,10 @@ cargo build --release
 - [x] Ficflow remembers which library/shelf tab was open when closed and reopens the same one
 - [x] Ability to choose the text size / zoom level in the settings
 - [x] New feature of auto-shelves (based on ships, fandoms, relationship,...)
+- [ ] Dark/White toggle in settings (dark, light, or follow computer theme)
+- [ ] Review Del behaviour while on a shelf
 - [ ] Fix alignment of the pinned icon
+- [ ] Fix behaviour for long notes
 - [ ] Possibility to choose the location of the library (defaults to appdata/ ~/.ficflow like now), with persistence of that config
 - [ ] Release the software on the AUR (can we make both the CLI and GUI work at the same time?)
 - [ ] Import/Export database to create backups

--- a/src/interfaces/gui/views/sidebar.rs
+++ b/src/interfaces/gui/views/sidebar.rs
@@ -269,10 +269,7 @@ fn shelf_rows(
             current_view,
             View::Shelf(shelf.id),
             &shelf.name,
-            // U+FE0E forces the plain "text" glyph variant rather than a
-            // wider emoji-style rendering, which otherwise bakes in extra
-            // left padding that throws off alignment vs. other icons.
-            is_auto.then_some("\u{2699}\u{FE0E}"),
+            is_auto.then_some("\u{2699}"),
             Some(count),
             Some(TreeRow {
                 depth,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(all(windows, not(debug_assertions)), windows_subsystem = "windows")]
+
 use std::process::ExitCode;
 
 use ficflow::infrastructure::external::ao3::fetcher::ao3_urls_from_env;


### PR DESCRIPTION
## Summary

Two Windows-only fixes found while testing the built app, plus roadmap notes.

- **No more stray terminal window.** The GUI launched a console window alongside it (closing the console killed the app). Release Windows builds now link as a GUI-subsystem app via `#![cfg_attr(all(windows, not(debug_assertions)), windows_subsystem = "windows")]`. Gated to release so debug Windows builds keep their log console; inert on Linux/macOS. CLI-on-Windows output is intentionally suppressed (Windows is GUI-only).
- **No more square next to auto-shelf names.** The gear was drawn as `"\u{2699}\u{FE0E}"`; the trailing variation selector (U+FE0E) has no glyph in the Windows fallback fonts and rendered as tofu. Dropped it to `"\u{2699}"`. Alignment is unchanged — the icon paints at a fixed anchor and the label reserves a fixed column, so glyph metrics never affected the name position.
- **Roadmap.** Added items for a dark/light theme toggle, reviewing Del behaviour on a shelf, and fixing long-note behaviour.

## Verification
- `cargo build` passes; auto-shelf gear renders correctly on Linux with no regression.
- The two Windows fixes require a **Windows release build** to fully verify: double-click `ficflow.exe` → no terminal window, app stays open, and auto-shelf rows show the gear with no trailing square.
