### PR TITLE
:construction_worker: Sync Cargo.toml/lock version in the release bump PR

### DIFF
--- a/.github/workflows/aur-publish.yml
+++ b/.github/workflows/aur-publish.yml
@@ -1,8 +1,10 @@
 name: Publish to AUR
 
 # Fires after the Release workflow succeeds on a v* tag.
-# Bumps pkgver in aur/PKGBUILD via an auto-merging PR (master is
-# protected by a PR-required ruleset), then publishes to AUR.
+# Publishes to AUR, then opens an auto-merging PR (master is protected
+# by a PR-required ruleset) that syncs the in-repo version with the
+# release: pkgver in aur/PKGBUILD plus the package version in
+# Cargo.toml / Cargo.lock (so a local `cargo run` shows the right one).
 on:
   workflow_run:
     workflows: ["Release"]
@@ -39,6 +41,14 @@ jobs:
           sed -i "s/^pkgver=.*/pkgver=${{ steps.version.outputs.version }}/" aur/PKGBUILD
           sed -i "s/^pkgrel=.*/pkgrel=1/" aur/PKGBUILD
 
+      - name: Bump package version in Cargo.toml and Cargo.lock
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          sed -i "s/^version = .*/version = \"$VERSION\"/" Cargo.toml
+          sed -i "/^name = \"ficflow\"\$/{n;s/^version = .*/version = \"$VERSION\"/}" Cargo.lock
+          grep '^version' Cargo.toml
+          grep -A2 '^name = "ficflow"' Cargo.lock
+
       - name: Publish to AUR
         uses: KSXGitHub/github-actions-deploy-aur@v4.1.3
         with:
@@ -60,13 +70,15 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v8
         with:
-          branch: aur-bump/${{ steps.version.outputs.version }}
+          branch: version-bump/${{ steps.version.outputs.version }}
           base: master
-          title: ":bookmark: Bump aur/PKGBUILD to ${{ steps.version.outputs.version }}"
-          commit-message: ":bookmark: Bump aur/PKGBUILD to ${{ steps.version.outputs.version }}"
+          title: ":bookmark: Bump version to ${{ steps.version.outputs.version }}"
+          commit-message: ":bookmark: Bump version to ${{ steps.version.outputs.version }}"
           body: |
             Auto-generated after the release of v${{ steps.version.outputs.version }}.
-            Keeps the in-repo PKGBUILD in sync with what's published to AUR.
+            Syncs the in-repo version with the release across Cargo.toml,
+            Cargo.lock, and aur/PKGBUILD, so the version shown in Settings on a
+            local `cargo run` stays in step with the latest release.
           delete-branch: true
 
       - name: Enable auto-merge on the bump PR


### PR DESCRIPTION
## Summary

Extends the post-release auto-merging PR (the one that already bumps `pkgver` in `aur/PKGBUILD`) to also bump the package version in **Cargo.toml** and **Cargo.lock**.

### Why
Released binaries already show the correct version — the [release workflow](.github/workflows/release.yml) rewrites `Cargo.toml` to the tag before building, on the tag, so `build.rs` emits e.g. `1.3.0`. But that rewrite is never committed back, so master's `Cargo.toml` stays at its old value. As a result a local `cargo run` from a working checkout shows a stale base version like `1.0.0-dev+<sha>` in Settings. Folding the manifest bump into the existing bump PR keeps the in-repo version in step with the latest release, so `cargo run` shows `<latest>-dev+<sha>`.

### Change
In [aur-publish.yml](.github/workflows/aur-publish.yml), a new step seds the tag version into `Cargo.toml` (package version only) and the `ficflow` entry in `Cargo.lock`, alongside the existing `PKGBUILD` bump. The PR title/branch/body are broadened from "Bump aur/PKGBUILD" to "Bump version". No extra PR is created — it's the same auto-merging one.

## Verification
- Dry-ran both `sed` commands against the current `Cargo.toml`/`Cargo.lock`: each touches exactly one line (the package version and the `ficflow` lock entry), leaving all dependency versions untouched.
