### PR TITLE
:sparkles: Add a Dark/Clear/System theme setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ cargo build --release
 - [x] Ficflow remembers which library/shelf tab was open when closed and reopens the same one
 - [x] Ability to choose the text size / zoom level in the settings
 - [x] New feature of auto-shelves (based on ships, fandoms, relationship,...)
-- [ ] Dark/White toggle in settings (dark, light, or follow computer theme)
+- [x] Dark/White toggle in settings (dark, light, or follow computer theme)
 - [ ] Review Del behaviour while on a shelf
 - [ ] Fix alignment of the pinned icon
 - [ ] Fix behaviour for long notes

--- a/src/interfaces/gui/app.rs
+++ b/src/interfaces/gui/app.rs
@@ -4,7 +4,7 @@ use egui_notify::Toasts;
 use rusqlite::Connection;
 
 use super::auto_shelf;
-use super::config::{self, AppConfig, ColumnKey, SortDirection, SortPref};
+use super::config::{self, AppConfig, ColumnKey, SortDirection, SortPref, ThemeChoice};
 use crate::application::{
     add_to_shelf::add_to_shelf, create_shelf::create_shelf, delete_fic, delete_shelf, move_shelf,
     pin_shelf::pin_shelf, remove_from_shelf, rename_shelf::rename_shelf, unpin_shelf::unpin_shelf,
@@ -135,6 +135,7 @@ impl FicflowApp {
         let chrome = FrameChrome::new().map_err(InitError::Chrome)?;
         let mut app_config = AppConfig::load();
         app_config.text_zoom = config::set_zoom(ctx, app_config.text_zoom);
+        config::set_theme(ctx, app_config.theme);
         let sort = app_config.default_sort;
         let current_view = app_config
             .last_view
@@ -214,6 +215,16 @@ impl FicflowApp {
 
     pub fn set_sort(&mut self, column: ColumnKey, direction: SortDirection) {
         self.sort = SortPref { column, direction };
+    }
+
+    pub fn theme_choice(&self) -> ThemeChoice {
+        self.config.theme
+    }
+
+    pub fn set_theme(&mut self, ctx: &egui::Context, choice: ThemeChoice) {
+        self.config.theme = choice;
+        config::set_theme(ctx, choice);
+        self.save_config();
     }
 
     pub fn visible_ids(&self) -> Vec<u64> {

--- a/src/interfaces/gui/app.rs
+++ b/src/interfaces/gui/app.rs
@@ -830,7 +830,7 @@ impl FicflowApp {
                         egui::RichText::new("FICFLOW")
                             .family(egui::FontFamily::Name(theme::NEUE_FAMILY.into()))
                             .size(20.0)
-                            .color(theme::ACCENT),
+                            .color(theme::accent(ui.visuals())),
                     )
                     .selectable(false),
                 );
@@ -1284,7 +1284,7 @@ impl FicflowApp {
                     egui::RichText::new(view_title)
                         .family(egui::FontFamily::Name(theme::NEUE_FAMILY.into()))
                         .size(20.0)
-                        .color(theme::ACCENT),
+                        .color(theme::accent(ui.visuals())),
                 )
                 .selectable(false),
             );

--- a/src/interfaces/gui/chrome.rs
+++ b/src/interfaces/gui/chrome.rs
@@ -154,9 +154,10 @@ impl FrameChrome {
             ),
         ];
 
+        let tint = theme::frame_tint(&ctx.global_style().visuals);
         for (dest, src) in tiles {
             if dest.width() > 0.0 && dest.height() > 0.0 {
-                painter.image(texture.id(), dest, src, Color32::WHITE);
+                painter.image(texture.id(), dest, src, tint);
             }
         }
     }
@@ -359,6 +360,7 @@ impl FrameChrome {
             .fixed_pos(origin)
             .interactable(true)
             .show(ui.ctx(), |area_ui| {
+                let accent = theme::accent(&area_ui.ctx().global_style().visuals);
                 for (i, button) in buttons.iter().enumerate() {
                     let rect = Rect::from_min_size(
                         Pos2::new(
@@ -373,9 +375,9 @@ impl FrameChrome {
                         area_ui.ctx().set_cursor_icon(CursorIcon::PointingHand);
                     }
                     let fill = if resp.is_pointer_button_down_on() {
-                        Color32::from_rgba_unmultiplied(0xC9, 0xC4, 0xBC, 80)
+                        Color32::from_rgba_unmultiplied(accent.r(), accent.g(), accent.b(), 80)
                     } else if hover {
-                        Color32::from_rgba_unmultiplied(0xC9, 0xC4, 0xBC, 40)
+                        Color32::from_rgba_unmultiplied(accent.r(), accent.g(), accent.b(), 40)
                     } else {
                         Color32::TRANSPARENT
                     };
@@ -384,7 +386,7 @@ impl FrameChrome {
                         rect,
                         4.0,
                         fill,
-                        Stroke::new(1.0_f32, theme::ACCENT),
+                        Stroke::new(1.0_f32, accent),
                         StrokeKind::Inside,
                     );
                     painter.text(
@@ -392,7 +394,7 @@ impl FrameChrome {
                         egui::Align2::CENTER_CENTER,
                         button.label,
                         egui::FontId::proportional(11.0),
-                        theme::ACCENT,
+                        accent,
                     );
                     if resp.clicked() {
                         (button.action)(area_ui.ctx());

--- a/src/interfaces/gui/config.rs
+++ b/src/interfaces/gui/config.rs
@@ -1,8 +1,8 @@
 //! Persistent GUI preferences stored as TOML at the platform's config
 //! dir (`~/.config/ficflow/config.toml` on Linux). Holds visible
 //! columns, the default sort for the library table, the
-//! maximized/fullscreen window state, and the text-zoom level — read
-//! at startup, written when the user changes them.
+//! maximized/fullscreen window state, the text-zoom level, and the
+//! theme choice — read at startup, written when the user changes them.
 //!
 //! Lives under `interfaces/gui/` because every field here is a GUI
 //! concern: column visibility, sort direction, and window state have
@@ -93,6 +93,34 @@ impl ColumnKey {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub enum ThemeChoice {
+    Dark,
+    Clear,
+    #[default]
+    System,
+}
+
+impl ThemeChoice {
+    pub const ALL: [ThemeChoice; 3] = [ThemeChoice::System, ThemeChoice::Clear, ThemeChoice::Dark];
+
+    pub fn label(self) -> &'static str {
+        match self {
+            ThemeChoice::System => "System",
+            ThemeChoice::Clear => "Clear",
+            ThemeChoice::Dark => "Dark",
+        }
+    }
+
+    fn preference(self) -> egui::ThemePreference {
+        match self {
+            ThemeChoice::System => egui::ThemePreference::System,
+            ThemeChoice::Clear => egui::ThemePreference::Light,
+            ThemeChoice::Dark => egui::ThemePreference::Dark,
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum SortDirection {
     Ascending,
@@ -135,6 +163,8 @@ pub struct AppConfig {
     /// against a hand-edited config file.
     #[serde(default = "default_text_zoom")]
     pub text_zoom: f32,
+    #[serde(default)]
+    pub theme: ThemeChoice,
 }
 
 pub const TEXT_ZOOM_RANGE: std::ops::RangeInclusive<f32> = 0.5..=2.0;
@@ -155,6 +185,10 @@ pub fn set_zoom(ctx: &egui::Context, zoom: f32) -> f32 {
     let clamped = clamp_zoom(zoom);
     ctx.set_zoom_factor(clamped);
     clamped
+}
+
+pub fn set_theme(ctx: &egui::Context, choice: ThemeChoice) {
+    ctx.set_theme(choice.preference());
 }
 
 impl Default for AppConfig {
@@ -178,6 +212,7 @@ impl Default for AppConfig {
             window_fullscreen: false,
             last_view: None,
             text_zoom: 1.0,
+            theme: ThemeChoice::System,
         }
     }
 }

--- a/src/interfaces/gui/mod.rs
+++ b/src/interfaces/gui/mod.rs
@@ -16,7 +16,7 @@ mod widgets;
 use std::process::ExitCode;
 
 pub use app::{FicflowApp, FicflowConfig, InitError};
-pub use config::{AppConfig, ColumnKey, SortDirection, SortPref};
+pub use config::{AppConfig, ColumnKey, SortDirection, SortPref, ThemeChoice};
 pub use selection::Selection;
 pub use tasks::{TaskKind, TaskState, TaskStatus};
 pub use view::View;

--- a/src/interfaces/gui/theme.rs
+++ b/src/interfaces/gui/theme.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use egui::{Color32, Context, FontData, FontDefinitions, FontFamily};
+use egui::{Color32, Context, FontData, FontDefinitions, FontFamily, Visuals};
 
 use super::assets;
 
@@ -9,6 +9,26 @@ use super::assets;
 /// wordmark and view-title heading so decorative type reads in the
 /// same family as the frame border.
 pub const ACCENT: Color32 = Color32::from_rgb(0xC9, 0xC4, 0xBC);
+
+const ACCENT_LIGHT_MODE: Color32 = Color32::from_rgb(0x6B, 0x64, 0x58);
+
+/// Multiplied against the frame texture at paint time; chosen so
+/// `ACCENT × FRAME_TINT_LIGHT_MODE / 255` lands on `ACCENT_LIGHT_MODE`,
+/// keeping the frame and decorative type in the same family in light
+/// mode without a second SVG.
+const FRAME_TINT_LIGHT_MODE: Color32 = Color32::from_rgb(0x87, 0x82, 0x79);
+
+pub fn accent(visuals: &Visuals) -> Color32 {
+    pick(visuals, ACCENT, ACCENT_LIGHT_MODE)
+}
+
+pub fn frame_tint(visuals: &Visuals) -> Color32 {
+    pick(visuals, Color32::WHITE, FRAME_TINT_LIGHT_MODE)
+}
+
+pub fn pick(visuals: &Visuals, dark: Color32, light: Color32) -> Color32 {
+    if visuals.dark_mode { dark } else { light }
+}
 
 pub const NEUE_FAMILY: &str = "neue";
 pub const COMFORTAA_FAMILY: &str = "comfortaa";

--- a/src/interfaces/gui/views/library_view.rs
+++ b/src/interfaces/gui/views/library_view.rs
@@ -262,8 +262,12 @@ fn header_cell(
             Layout::centered_and_justified(egui::Direction::LeftToRight),
             |ui| {
                 ui.add(
-                    egui::Label::new(RichText::new(text).strong().color(theme::ACCENT))
-                        .selectable(false),
+                    egui::Label::new(
+                        RichText::new(text)
+                            .strong()
+                            .color(theme::accent(ui.visuals())),
+                    )
+                    .selectable(false),
                 );
             },
         );
@@ -292,7 +296,11 @@ fn header_cell(
                 egui::Order::Foreground,
                 egui::Id::new("column-reorder-indicator"),
             ))
-            .vline(x, rect.y_range(), Stroke::new(2.0_f32, theme::ACCENT));
+            .vline(
+                x,
+                rect.y_range(),
+                Stroke::new(2.0_f32, theme::accent(&resp.ctx.global_style().visuals)),
+            );
     }
     if let Some(dragged) = resp.dnd_release_payload::<ColumnKey>()
         && *dragged != column
@@ -444,7 +452,7 @@ fn is_centered_column(col: ColumnKey) -> bool {
 /// horizontally with its content rect. Fill must be opaque so the
 /// blue row-selection background doesn't bleed through and shift hue.
 fn render_status_pill(ui: &mut Ui, status: &ReadingStatus) {
-    let palette = status_palette(status);
+    let palette = status_palette(status, ui.visuals().dark_mode);
     let text = format_status(status);
     let body_font = egui::TextStyle::Body.resolve(ui.style());
     let galley = ui
@@ -470,34 +478,28 @@ fn render_status_pill(ui: &mut Ui, status: &ReadingStatus) {
 }
 
 struct StatusPalette {
-    /// Opaque dark tint for the pill background.
+    /// Opaque tint for the pill background.
     fill: Color32,
     /// Saturated hue for the outline and text.
     accent: Color32,
 }
 
-fn status_palette(status: &ReadingStatus) -> StatusPalette {
-    match status {
-        ReadingStatus::InProgress => StatusPalette {
-            fill: Color32::from_rgb(20, 30, 50),
-            accent: Color32::from_rgb(59, 130, 246),
-        },
-        ReadingStatus::Read => StatusPalette {
-            fill: Color32::from_rgb(20, 35, 25),
-            accent: Color32::from_rgb(34, 197, 94),
-        },
-        ReadingStatus::PlanToRead => StatusPalette {
-            fill: Color32::from_rgb(35, 25, 50),
-            accent: Color32::from_rgb(168, 85, 247),
-        },
-        ReadingStatus::Paused => StatusPalette {
-            fill: Color32::from_rgb(40, 30, 15),
-            accent: Color32::from_rgb(245, 158, 11),
-        },
-        ReadingStatus::Abandoned => StatusPalette {
-            fill: Color32::from_rgb(45, 20, 20),
-            accent: Color32::from_rgb(239, 68, 68),
-        },
+fn status_palette(status: &ReadingStatus, dark_mode: bool) -> StatusPalette {
+    let (fill, accent) = match (status, dark_mode) {
+        (ReadingStatus::InProgress, true) => ((20, 30, 50), (59, 130, 246)),
+        (ReadingStatus::InProgress, false) => ((219, 234, 254), (29, 78, 216)),
+        (ReadingStatus::Read, true) => ((20, 35, 25), (34, 197, 94)),
+        (ReadingStatus::Read, false) => ((220, 252, 231), (21, 128, 61)),
+        (ReadingStatus::PlanToRead, true) => ((35, 25, 50), (168, 85, 247)),
+        (ReadingStatus::PlanToRead, false) => ((243, 232, 255), (126, 34, 206)),
+        (ReadingStatus::Paused, true) => ((40, 30, 15), (245, 158, 11)),
+        (ReadingStatus::Paused, false) => ((254, 243, 199), (180, 83, 9)),
+        (ReadingStatus::Abandoned, true) => ((45, 20, 20), (239, 68, 68)),
+        (ReadingStatus::Abandoned, false) => ((254, 226, 226), (185, 28, 28)),
+    };
+    StatusPalette {
+        fill: Color32::from_rgb(fill.0, fill.1, fill.2),
+        accent: Color32::from_rgb(accent.0, accent.1, accent.2),
     }
 }
 

--- a/src/interfaces/gui/views/settings_view.rs
+++ b/src/interfaces/gui/views/settings_view.rs
@@ -1,7 +1,7 @@
 use chrono::NaiveDate;
 use egui::{RichText, ScrollArea, Ui};
 
-use super::super::config::{self, AppConfig, TEXT_ZOOM_RANGE};
+use super::super::config::{self, AppConfig, TEXT_ZOOM_RANGE, ThemeChoice};
 use super::super::format::erisian_date;
 use crate::version::{LICENSE, RELEASE_DATE, VERSION};
 
@@ -54,6 +54,22 @@ pub fn draw(ui: &mut Ui, config: &mut AppConfig) -> bool {
                 }
             });
             ui.label(RichText::new("Or use Ctrl/Cmd +/-/0.").weak().italics());
+
+            ui.add_space(6.0);
+            ui.horizontal(|ui| {
+                for choice in ThemeChoice::ALL {
+                    if ui
+                        .selectable_label(config.theme == choice, choice.label())
+                        .clicked()
+                        && config.theme != choice
+                    {
+                        config.theme = choice;
+                        config::set_theme(ui.ctx(), choice);
+                        changed = true;
+                    }
+                }
+                ui.label("Theme");
+            });
 
             ui.add_space(12.0);
             ui.label(RichText::new("Paths").strong());

--- a/src/interfaces/gui/views/settings_view.rs
+++ b/src/interfaces/gui/views/settings_view.rs
@@ -55,7 +55,8 @@ pub fn draw(ui: &mut Ui, config: &mut AppConfig) -> bool {
             });
             ui.label(RichText::new("Or use Ctrl/Cmd +/-/0.").weak().italics());
 
-            ui.add_space(6.0);
+            ui.add_space(12.0);
+            ui.label(RichText::new("Theme").strong());
             ui.horizontal(|ui| {
                 for choice in ThemeChoice::ALL {
                     if ui
@@ -68,7 +69,6 @@ pub fn draw(ui: &mut Ui, config: &mut AppConfig) -> bool {
                         changed = true;
                     }
                 }
-                ui.label("Theme");
             });
 
             ui.add_space(12.0);

--- a/src/interfaces/gui/views/sidebar.rs
+++ b/src/interfaces/gui/views/sidebar.rs
@@ -537,7 +537,7 @@ fn view_row(
 
     // Pin toggle icon, painted on top of the label like the count badge.
     // Only shown for pinned shelves, or on hover so unpinned shelves don't
-    // clutter the row — `theme::ACCENT` rather than the selection blue so
+    // clutter the row — `theme::accent` rather than the selection blue so
     // it stays visible when the row itself is selected/highlighted.
     let mut pin_clicked = false;
     if let (Some(pin_rect), Some(TreeRow { pinned, .. })) = (pin_rect, tree) {
@@ -545,7 +545,7 @@ fn view_row(
         pin_clicked = pin_resp.clicked();
         if pinned || resp.hovered() || pin_resp.hovered() {
             let color = if pinned {
-                theme::ACCENT
+                theme::accent(ui.visuals())
             } else {
                 ui.style().visuals.weak_text_color()
             };

--- a/src/interfaces/gui/views/tasks_view.rs
+++ b/src/interfaces/gui/views/tasks_view.rs
@@ -2,6 +2,7 @@ use chrono::{DateTime, Utc};
 use egui::{Align, Layout, RichText, ScrollArea, Ui};
 
 use super::super::tasks::{TaskExecutor, TaskKind, TaskState, TaskStatus};
+use super::super::theme;
 
 #[derive(Clone, Copy, Default, PartialEq, Eq)]
 pub enum TaskFilter {
@@ -102,19 +103,21 @@ pub fn draw(ui: &mut Ui, state: TasksViewState<'_>) {
                                 ui.label("Running");
                             }
                             TaskStatus::Done => {
-                                ui.label(
-                                    RichText::new("Done")
-                                        .color(egui::Color32::from_rgb(120, 200, 120)),
-                                );
+                                ui.label(RichText::new("Done").color(theme::pick(
+                                    ui.visuals(),
+                                    egui::Color32::from_rgb(120, 200, 120),
+                                    egui::Color32::from_rgb(30, 130, 60),
+                                )));
                             }
                             TaskStatus::Failed(_) => {
                                 if ui.button("Retry").clicked() {
                                     executor.retry(task.id);
                                 }
-                                ui.label(
-                                    RichText::new("Failed")
-                                        .color(egui::Color32::from_rgb(220, 100, 100)),
-                                );
+                                ui.label(RichText::new("Failed").color(theme::pick(
+                                    ui.visuals(),
+                                    egui::Color32::from_rgb(220, 100, 100),
+                                    egui::Color32::from_rgb(185, 40, 40),
+                                )));
                             }
                         }
                     });
@@ -123,9 +126,11 @@ pub fn draw(ui: &mut Ui, state: TasksViewState<'_>) {
                 // wrapped to the panel width.
                 if let TaskStatus::Failed(msg) = &task.status {
                     ui.add(
-                        egui::Label::new(
-                            RichText::new(msg).color(egui::Color32::from_rgb(220, 100, 100)),
-                        )
+                        egui::Label::new(RichText::new(msg).color(theme::pick(
+                            ui.visuals(),
+                            egui::Color32::from_rgb(220, 100, 100),
+                            egui::Color32::from_rgb(185, 40, 40),
+                        )))
                         .wrap()
                         .selectable(true),
                     );

--- a/tests/gui.rs
+++ b/tests/gui.rs
@@ -48,3 +48,6 @@ mod columns;
 
 #[path = "gui/last_view.rs"]
 mod last_view;
+
+#[path = "gui/theme.rs"]
+mod theme;

--- a/tests/gui/theme.rs
+++ b/tests/gui/theme.rs
@@ -1,0 +1,81 @@
+#[cfg(test)]
+mod tests {
+    use ficflow::interfaces::gui::{AppConfig, ThemeChoice};
+
+    use crate::common::fixtures;
+    use crate::harness::GuiHarness;
+
+    fn given_harness() -> GuiHarness {
+        let (conn, db_path, td) = fixtures::given_test_database();
+        GuiHarness::with_db(vec!["http://127.0.0.1:1".into()], conn, db_path, td)
+    }
+
+    #[test]
+    fn default_theme_is_system() {
+        assert_eq!(AppConfig::default().theme, ThemeChoice::System);
+    }
+
+    #[test]
+    fn config_without_theme_key_falls_back_to_system() {
+        let text = r#"
+            visible_columns = ["Title"]
+
+            [default_sort]
+            column = "Updated"
+            direction = "Descending"
+        "#;
+
+        let cfg: AppConfig = toml::from_str(text).unwrap();
+
+        assert_eq!(cfg.theme, ThemeChoice::System);
+    }
+
+    #[test]
+    fn theme_choice_survives_config_round_trip() {
+        let cfg = AppConfig {
+            theme: ThemeChoice::Dark,
+            ..AppConfig::default()
+        };
+
+        let text = toml::to_string_pretty(&cfg).unwrap();
+        let reloaded: AppConfig = toml::from_str(&text).unwrap();
+
+        assert_eq!(reloaded.theme, ThemeChoice::Dark);
+    }
+
+    #[test]
+    fn clear_theme_applies_to_context_and_survives_restart() {
+        let mut h = given_harness();
+        let ctx = h.ctx.clone();
+
+        h.app.set_theme(&ctx, ThemeChoice::Clear);
+        h.step();
+
+        assert_eq!(h.ctx.theme(), egui::Theme::Light);
+
+        h.ctx.set_theme(egui::ThemePreference::System);
+        h.restart(vec!["http://127.0.0.1:1".into()]);
+
+        assert_eq!(h.app.theme_choice(), ThemeChoice::Clear);
+        assert_eq!(
+            h.ctx.options(|o| o.theme_preference),
+            egui::ThemePreference::Light
+        );
+    }
+
+    #[test]
+    fn system_theme_sets_system_preference() {
+        let mut h = given_harness();
+        let ctx = h.ctx.clone();
+
+        h.app.set_theme(&ctx, ThemeChoice::Dark);
+        h.app.set_theme(&ctx, ThemeChoice::System);
+        h.restart(vec!["http://127.0.0.1:1".into()]);
+
+        assert_eq!(h.app.theme_choice(), ThemeChoice::System);
+        assert_eq!(
+            h.ctx.options(|o| o.theme_preference),
+            egui::ThemePreference::System
+        );
+    }
+}


### PR DESCRIPTION
Adds a **Theme** control to Settings → Display with three options — **System** (default), **Clear**, **Dark** — persisted in `config.toml` and re-applied on launch.

## Changes
- `ThemeChoice` enum in `config.rs`, stored as `theme = "System" | "Clear" | "Dark"`; existing config files without the key default to System.
- Applied at startup in `FicflowApp::with_config` and live from the Settings row via `egui::ThemePreference` (System keeps following the OS).
- Clear-mode legibility fixes: theme-aware accent for the wordmark/view titles/table headers/pin icon/window controls, light variants for status pills and Tasks status colours, and the Art Nouveau frame tinted dark gray in light mode (paint-time tint only — the SVG asset is untouched, dark mode unchanged).

## Tests
`tests/gui/theme.rs`: default value, old-config fallback, TOML roundtrip, and a GuiHarness e2e that applies Clear, restarts, and asserts the choice and `ThemePreference` survive. Full suite: 68 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)