### PR TITLE
:sparkles: Offer remove-from-shelf vs delete when pressing Del on a shelf

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ cargo build --release
 - [x] Ability to choose the text size / zoom level in the settings
 - [x] New feature of auto-shelves (based on ships, fandoms, relationship,...)
 - [x] Dark/White toggle in settings (dark, light, or follow computer theme)
-- [ ] Review Del behaviour while on a shelf
+- [x] Review Del behaviour while on a shelf
 - [ ] Fix alignment of the pinned icon
 - [ ] Fix behaviour for long notes
 - [ ] Possibility to choose the location of the library (defaults to appdata/ ~/.ficflow like now), with persistence of that config

--- a/src/interfaces/gui/app.rs
+++ b/src/interfaces/gui/app.rs
@@ -92,6 +92,7 @@ pub enum ActiveModal {
     AutoShelf(AutoShelfState),
     DeleteShelf(u64),
     DeleteFics(Vec<u64>),
+    RemoveOrDeleteFics { ids: Vec<u64>, shelf_id: u64 },
     AddFic(AddFicState),
     ConfirmQuit,
 }
@@ -248,6 +249,19 @@ impl FicflowApp {
 
     pub fn confirm_quit_open(&self) -> bool {
         matches!(self.active_modal, ActiveModal::ConfirmQuit)
+    }
+
+    pub fn delete_fics_open(&self) -> bool {
+        matches!(self.active_modal, ActiveModal::DeleteFics(_))
+    }
+
+    /// `Some(shelf_id)` when the "remove from shelf vs delete" chooser is
+    /// the open modal.
+    pub fn remove_or_delete_shelf(&self) -> Option<u64> {
+        match self.active_modal {
+            ActiveModal::RemoveOrDeleteFics { shelf_id, .. } => Some(shelf_id),
+            _ => None,
+        }
     }
 
     pub fn task_states(&self) -> Vec<crate::interfaces::gui::tasks::TaskState> {
@@ -516,6 +530,13 @@ impl FicflowApp {
                 .count()
         });
         (ids.len() - errors, errors)
+    }
+
+    fn is_normal_shelf(&self, shelf_id: u64) -> bool {
+        self.cache
+            .shelves
+            .iter()
+            .any(|s| s.id == shelf_id && matches!(s.kind, ShelfKind::Normal))
     }
 
     pub fn set_search(&mut self, query: impl Into<String>) {
@@ -1133,6 +1154,10 @@ impl FicflowApp {
             },
             DeleteShelf(u64),
             DeleteFics(Vec<u64>),
+            RemoveFicsFromShelf {
+                ids: Vec<u64>,
+                shelf_id: u64,
+            },
             AddFic(String),
             Quit,
         }
@@ -1181,6 +1206,26 @@ impl FicflowApp {
                     bulk_modals::DeleteOutcome::None => ModalAction::None,
                 }
             }
+            ActiveModal::RemoveOrDeleteFics { ids, shelf_id } => {
+                let shelf_id = *shelf_id;
+                let shelf_name = self
+                    .cache
+                    .shelves
+                    .iter()
+                    .find(|s| s.id == shelf_id)
+                    .map(|s| s.name.as_str())
+                    .unwrap_or("shelf");
+                match bulk_modals::draw_remove_or_delete(ctx, ids, shelf_name, &self.cache.fics) {
+                    bulk_modals::RemoveOrDeleteOutcome::RemoveFromShelf(ids) => {
+                        ModalAction::RemoveFicsFromShelf { ids, shelf_id }
+                    }
+                    bulk_modals::RemoveOrDeleteOutcome::DeleteEverywhere(ids) => {
+                        ModalAction::DeleteFics(ids)
+                    }
+                    bulk_modals::RemoveOrDeleteOutcome::Cancel => ModalAction::Close,
+                    bulk_modals::RemoveOrDeleteOutcome::None => ModalAction::None,
+                }
+            }
             ActiveModal::AddFic(state) => match add_fic_dialog::draw(ctx, state) {
                 add_fic_dialog::Outcome::Submit(input) => ModalAction::AddFic(input),
                 add_fic_dialog::Outcome::Cancel => ModalAction::Close,
@@ -1222,6 +1267,11 @@ impl FicflowApp {
             }
             ModalAction::DeleteFics(ids) => {
                 self.handle_bulk_delete(&ids);
+                self.active_modal = ActiveModal::None;
+            }
+            ModalAction::RemoveFicsFromShelf { ids, shelf_id } => {
+                let (succeeded, failed) = self.bulk_remove_from_shelf(&ids, shelf_id);
+                self.toast_bulk_result("Removed from shelf", succeeded, failed);
                 self.active_modal = ActiveModal::None;
             }
             ModalAction::AddFic(input) => {
@@ -1508,8 +1558,22 @@ impl FicflowApp {
 
         if pressed_delete {
             let selected_fics = self.selection.ids_vec();
-            if !selected_fics.is_empty() && self.current_view.shows_library() {
-                self.active_modal = ActiveModal::DeleteFics(selected_fics);
+            if !selected_fics.is_empty() {
+                if let View::Shelf(shelf_id) = &self.current_view {
+                    let shelf_id = *shelf_id;
+                    if self.is_normal_shelf(shelf_id) {
+                        self.active_modal = ActiveModal::RemoveOrDeleteFics {
+                            ids: selected_fics,
+                            shelf_id,
+                        };
+                    } else {
+                        // Auto-shelf membership is derived, not stored, so
+                        // there's nothing to remove from → delete-only.
+                        self.active_modal = ActiveModal::DeleteFics(selected_fics);
+                    }
+                } else if self.current_view.shows_library() {
+                    self.active_modal = ActiveModal::DeleteFics(selected_fics);
+                }
             } else if let View::Shelf(shelf_id) = &self.current_view {
                 // No fic selection on a shelf view → Delete targets the
                 // shelf itself.

--- a/src/interfaces/gui/views/modals/bulk_modals.rs
+++ b/src/interfaces/gui/views/modals/bulk_modals.rs
@@ -58,3 +58,74 @@ pub fn draw_delete_confirm(ctx: &Context, ids: &[u64], fics: &[Fanfiction]) -> D
     }
     outcome
 }
+
+pub enum RemoveOrDeleteOutcome {
+    None,
+    RemoveFromShelf(Vec<u64>),
+    DeleteEverywhere(Vec<u64>),
+    Cancel,
+}
+
+pub fn draw_remove_or_delete(
+    ctx: &Context,
+    ids: &[u64],
+    shelf_name: &str,
+    fics: &[Fanfiction],
+) -> RemoveOrDeleteOutcome {
+    let total = ids.len();
+
+    let mut still_open = true;
+    let mut outcome = RemoveOrDeleteOutcome::None;
+    Window::new("Remove or delete")
+        .open(&mut still_open)
+        .resizable(false)
+        .collapsible(false)
+        .pivot(egui::Align2::CENTER_CENTER)
+        .default_pos(ctx.content_rect().center())
+        .show(ctx, |ui| {
+            ui.label(format!("{} fanfiction(s) selected", total));
+            ui.add_space(4.0);
+            for id in ids.iter().take(MAX_TITLES_SHOWN) {
+                let title = fics
+                    .iter()
+                    .find(|f| f.id == *id)
+                    .map(|f| f.title.as_str())
+                    .unwrap_or("(unknown)");
+                ui.label(format!("• {}", title));
+            }
+            if total > MAX_TITLES_SHOWN {
+                ui.label(
+                    egui::RichText::new(format!("+ {} more", total - MAX_TITLES_SHOWN))
+                        .italics()
+                        .weak(),
+                );
+            }
+            ui.add_space(4.0);
+            ui.label(
+                egui::RichText::new(
+                    "Removing keeps them in Ficflow; deleting removes them everywhere.",
+                )
+                .italics()
+                .weak(),
+            );
+            ui.add_space(6.0);
+            ui.horizontal(|ui| {
+                if ui
+                    .button(format!("Remove from \"{}\"", shelf_name))
+                    .clicked()
+                {
+                    outcome = RemoveOrDeleteOutcome::RemoveFromShelf(ids.to_vec());
+                }
+                if ui.button("Delete from Ficflow").clicked() {
+                    outcome = RemoveOrDeleteOutcome::DeleteEverywhere(ids.to_vec());
+                }
+                if ui.button("Cancel").clicked() {
+                    outcome = RemoveOrDeleteOutcome::Cancel;
+                }
+            });
+        });
+    if !still_open {
+        outcome = RemoveOrDeleteOutcome::Cancel;
+    }
+    outcome
+}

--- a/tests/gui.rs
+++ b/tests/gui.rs
@@ -51,3 +51,6 @@ mod last_view;
 
 #[path = "gui/theme.rs"]
 mod theme;
+
+#[path = "gui/shelf_delete_key.rs"]
+mod shelf_delete_key;

--- a/tests/gui/harness.rs
+++ b/tests/gui/harness.rs
@@ -149,6 +149,26 @@ impl GuiHarness {
         })
     }
 
+    /// Run one frame with a single key press injected, so shortcut
+    /// handlers (`handle_shortcuts`) see `key_pressed(key)` this frame.
+    pub fn step_with_key(&mut self, key: egui::Key) {
+        let mut raw_input = egui::RawInput {
+            max_texture_side: Some(8192),
+            ..Default::default()
+        };
+        raw_input.events.push(egui::Event::Key {
+            key,
+            physical_key: None,
+            pressed: true,
+            repeat: false,
+            modifiers: egui::Modifiers::default(),
+        });
+        let app = &mut self.app;
+        let _ = self.ctx.run_ui(raw_input, |ui| {
+            app.render(ui);
+        });
+    }
+
     pub fn step_n(&mut self, n: usize) {
         for _ in 0..n {
             self.step();

--- a/tests/gui/shelf_delete_key.rs
+++ b/tests/gui/shelf_delete_key.rs
@@ -1,0 +1,86 @@
+//! Delete key on a shelf view — routing between "remove from shelf"
+//! and "delete from Ficflow".
+//!
+//! Pressing Delete with fics selected used to jump straight to a full
+//! delete confirmation, even on a shelf. On a normal shelf it must now
+//! open the remove-or-delete chooser instead. Auto-shelves (membership
+//! is derived, nothing to remove from) and non-shelf library views keep
+//! the plain delete-fics confirmation.
+
+#[cfg(test)]
+mod tests {
+    use ficflow::domain::fanfiction::ReadingStatus;
+    use ficflow::domain::shelf::{AutoShelfCriteria, Clause, ClauseLogic};
+    use ficflow::interfaces::gui::View;
+
+    use crate::common::fixtures;
+    use crate::harness::GuiHarness;
+
+    fn given_harness_with_n_fics(n: u64) -> (GuiHarness, Vec<u64>) {
+        let (conn, db_path, td) = fixtures::given_test_database();
+        let ids: Vec<u64> = (1..=n).collect();
+        for id in &ids {
+            let fic = fixtures::given_sample_fanfiction(*id, &format!("Fic {}", id));
+            fixtures::when_fanfiction_added_to_db(&conn, &fic).unwrap();
+        }
+        let h = GuiHarness::with_db(vec!["http://127.0.0.1:1".into()], conn, db_path, td);
+        (h, ids)
+    }
+
+    #[test]
+    fn delete_key_on_normal_shelf_opens_remove_or_delete_chooser() {
+        let (mut h, ids) = given_harness_with_n_fics(3);
+        h.step_n(1);
+        h.app.create_shelf("Beloveds").unwrap();
+        let shelf_id = h.app.shelves()[0].id;
+        for id in &ids {
+            h.app.add_fic_to_shelf(*id, shelf_id).unwrap();
+        }
+        h.app.open_view(View::Shelf(shelf_id));
+        h.step();
+        h.app.select_fics(&ids);
+
+        h.step_with_key(egui::Key::Delete);
+
+        assert_eq!(h.app.remove_or_delete_shelf(), Some(shelf_id));
+        assert!(!h.app.delete_fics_open());
+    }
+
+    #[test]
+    fn delete_key_on_auto_shelf_falls_back_to_delete_confirm() {
+        let (conn, db_path, td) = fixtures::given_test_database();
+        let mut fic = fixtures::given_sample_fanfiction(601, "Solo");
+        fic.reading_status = ReadingStatus::Read;
+        fixtures::when_fanfiction_added_to_db(&conn, &fic).unwrap();
+        let mut h = GuiHarness::with_db(vec!["http://127.0.0.1:1".into()], conn, db_path, td);
+        h.step_n(1);
+
+        let criteria = AutoShelfCriteria {
+            logic: ClauseLogic::Or,
+            clauses: vec![Clause::Status(ReadingStatus::Read)],
+        };
+        h.app.upsert_auto_shelf(None, "Read", criteria).unwrap();
+        let shelf_id = h.app.shelves()[0].id;
+        h.app.open_view(View::Shelf(shelf_id));
+        h.step();
+        h.app.select_fics(&[601]);
+
+        h.step_with_key(egui::Key::Delete);
+
+        assert!(h.app.delete_fics_open());
+        assert_eq!(h.app.remove_or_delete_shelf(), None);
+    }
+
+    #[test]
+    fn delete_key_on_all_fics_view_opens_delete_confirm() {
+        let (mut h, ids) = given_harness_with_n_fics(2);
+        h.step_n(1);
+        assert!(matches!(h.app.current_view(), View::AllFics));
+        h.app.select_fics(&ids);
+
+        h.step_with_key(egui::Key::Delete);
+
+        assert!(h.app.delete_fics_open());
+        assert_eq!(h.app.remove_or_delete_shelf(), None);
+    }
+}


### PR DESCRIPTION
## What & why

Pressing **Del** on a shelf with one or more fics selected used to jump straight to a full *delete-from-Ficflow* confirmation. On a shelf, the expected meaning of Del is usually "take these off *this* shelf" — not "erase them everywhere". This adds that choice.

## Behaviour

- **Normal shelf, fics selected + Del** → a chooser modal:
  > N fanfiction(s) selected · *"Removing keeps them in Ficflow; deleting removes them everywhere."*
  > `[Remove from "<shelf>"]`  `[Delete from Ficflow]`  `[Cancel]`

  "Remove from shelf" is the primary (leftmost, safest) action.
- **Auto-shelf** (membership is derived, nothing to remove) → unchanged: plain delete confirmation.
- **All-fics / By-status views** → unchanged: plain delete confirmation.
- **Selection-bar trash button** → unchanged (it sits next to a dedicated "Remove from shelf" button already).

## Implementation

- New `ActiveModal::RemoveOrDeleteFics { ids, shelf_id }` variant + reordered Del-key branch (routes normal shelves via a new `is_normal_shelf` helper).
- New `draw_remove_or_delete` / `RemoveOrDeleteOutcome` in `bulk_modals.rs`, mirroring the existing `draw_delete_confirm`.
- Dispatch reuses the existing `bulk_remove_from_shelf` and `handle_bulk_delete` — **no data-layer changes**.

## Tests

3 new headless GUI e2e cases in `tests/gui/shelf_delete_key.rs` (injecting a real Del keypress via a new `step_with_key` harness helper): normal-shelf → chooser, auto-shelf → delete-only, all-fics → delete-only. Full suite green, clippy clean.