### PR TITLE
:sparkles: Customizable library location with backup restore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,6 +186,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "ashpd"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f3f79755c74fd155000314eb349864caa787c6592eace6c6882dad873d9c39"
+dependencies = [
+ "async-fs",
+ "async-net",
+ "enumflags2",
+ "futures-channel",
+ "futures-util",
+ "rand 0.9.4",
+ "raw-window-handle",
+ "serde",
+ "serde_repr",
+ "url",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "zbus",
+]
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -211,6 +233,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,6 +266,49 @@ dependencies = [
  "compression-core",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-fs"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5"
+dependencies = [
+ "async-lock",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix 1.1.4",
+ "slab",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -234,6 +323,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-net"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7"
+dependencies = [
+ "async-io",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
 name = "async-object-pool"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -244,6 +344,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix 1.1.4",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix 1.1.4",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -251,7 +404,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -352,6 +505,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -385,7 +551,7 @@ checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -532,7 +698,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -746,7 +912,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -779,7 +945,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -832,6 +998,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags 2.11.1",
+ "block2 0.6.2",
+ "libc",
  "objc2 0.6.4",
 ]
 
@@ -843,7 +1011,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1066,6 +1234,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
 name = "enum-map"
 version = "2.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1082,7 +1256,28 @@ checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1093,7 +1288,7 @@ checksum = "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1262,6 +1457,7 @@ dependencies = [
  "regex",
  "reqwest",
  "resvg",
+ "rfd",
  "rusqlite",
  "rusqlite_migration",
  "scraper",
@@ -1375,7 +1571,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1422,6 +1618,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1429,7 +1638,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1769,6 +1978,12 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hexf-parse"
@@ -2148,7 +2363,7 @@ checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2178,7 +2393,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2206,7 +2421,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2554,7 +2769,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2605,6 +2820,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.11.1",
+ "block2 0.6.2",
  "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -2904,6 +3120,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3021,7 +3247,7 @@ dependencies = [
  "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "unicase",
 ]
 
@@ -3035,7 +3261,7 @@ dependencies = [
  "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3080,7 +3306,7 @@ checksum = "a990e22f43e84855daf260dded30524ef4a9021cc7541c26540500a50b624389"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3088,6 +3314,17 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
 
 [[package]]
 name = "pkg-config"
@@ -3216,7 +3453,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3546,6 +3783,30 @@ dependencies = [
  "tiny-skia",
  "usvg",
  "zune-jpeg",
+]
+
+[[package]]
+name = "rfd"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef2bee61e6cffa4635c72d7d81a84294e28f0930db0ddcb0f66d10244674ebed"
+dependencies = [
+ "ashpd",
+ "block2 0.6.2",
+ "dispatch2",
+ "js-sys",
+ "log",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "pollster",
+ "raw-window-handle",
+ "urlencoding",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3907,7 +4168,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3931,6 +4192,17 @@ checksum = "a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf"
 dependencies = [
  "regex",
  "serde",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4230,7 +4502,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4261,6 +4533,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4277,7 +4560,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4364,7 +4647,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4375,7 +4658,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4467,7 +4750,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4614,7 +4897,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4661,6 +4944,17 @@ name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "unicase"
@@ -4750,7 +5044,14 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "usvg"
@@ -4804,7 +5105,9 @@ version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
+ "js-sys",
  "serde_core",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -4939,7 +5242,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -5446,7 +5749,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5457,7 +5760,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5764,7 +6067,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -5780,7 +6083,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -5916,8 +6219,69 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
+]
+
+[[package]]
+name = "zbus"
+version = "5.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe18fb60dc696039e738717b76eaea21e7a4489bbb1885020b43c94236d7e98a"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix 1.1.4",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe96480bed92df2b442a1a30df364e12d08eed03aeb061f2b8dc6afb2be91119"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8bf88b4a3ff53e883001e0e0115b297a9d53c31b9c1edd2bfdd853e3428624e"
+dependencies = [
+ "serde",
+ "winnow",
+ "zvariant",
 ]
 
 [[package]]
@@ -5937,7 +6301,7 @@ checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5957,7 +6321,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -5997,7 +6361,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6019,4 +6383,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
 dependencies = [
  "zune-core",
+]
+
+[[package]]
+name = "zvariant"
+version = "5.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee2a0bcd2a907786a456fff45aaaaf54c9ba5f50b71ae9ec1a4edd200c94911"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "url",
+ "winnow",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38a708216a18780796770bfe3f4739c7c83a3e8f789b755534bbbc06e4e23e12"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90cb9383f9b45290407a1258b202d3f8f01db719eb60b4e4055c6375af4fc7c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.117",
+ "winnow",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ egui_extras = "0.34"
 egui-notify = "0.22"
 toml = "1"
 resvg = "0.47"
+rfd = { version = "0.15", default-features = false, features = ["xdg-portal", "async-std"] }
 
 [dev-dependencies]
 httpmock = "0.8.3"

--- a/README.md
+++ b/README.md
@@ -80,16 +80,6 @@ cargo build --release
 ## Features (Planned, the order is approximate)
 
 - [ ] Revert the details-panel custom resize handle once egui 0.35 is out — the fix ([emilk/egui#8198](https://github.com/emilk/egui/pull/8198), merged 2026-05-26, superseding #8056) was kept out of 0.34.x patch releases (re-enable `Panel::right(...).resizable(true)`). Update : blocked by egui-notify ; they need to have a compatible version with 0.35 egui
-- [x] Ficflow remembers which library/shelf tab was open when closed and reopens the same one
-- [x] Ability to choose the text size / zoom level in the settings
-- [x] New feature of auto-shelves (based on ships, fandoms, relationship,...)
-- [x] Dark/White toggle in settings (dark, light, or follow computer theme)
-- [x] Review Del behaviour while on a shelf
-- [ ] Fix alignment of the pinned icon
-- [ ] Fix behaviour for long notes
-- [x] Possibility to choose the location of the library (defaults to appdata/ ~/.ficflow like now), with persistence of that config
-- [ ] Release the software on the AUR (can we make both the CLI and GUI work at the same time?)
-- [ ] Import/Export database to create backups
 - [ ] In the settings, after the version, display some warning in red if a newer version is available
 - [ ] Ability to login to access restricted fics
 - [ ] Create a rule that automatically checks for updates when the GUI is open and sends notifications to the user in case there is a new one (settings, refresh every x time, + notifications for all manual and auto refreshes when a new update was found! And an inbox too)

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ cargo build --release
 - [x] Review Del behaviour while on a shelf
 - [ ] Fix alignment of the pinned icon
 - [ ] Fix behaviour for long notes
-- [ ] Possibility to choose the location of the library (defaults to appdata/ ~/.ficflow like now), with persistence of that config
+- [x] Possibility to choose the location of the library (defaults to appdata/ ~/.ficflow like now), with persistence of that config
 - [ ] Release the software on the AUR (can we make both the CLI and GUI work at the same time?)
 - [ ] Import/Export database to create backups
 - [ ] In the settings, after the version, display some warning in red if a newer version is available

--- a/src/infrastructure/mod.rs
+++ b/src/infrastructure/mod.rs
@@ -2,5 +2,7 @@ pub mod external;
 pub mod persistence;
 
 pub use external::ao3::Ao3Fetcher;
-pub use persistence::database::establish_connection;
+pub use persistence::database::{
+    default_db_path, open_configured_db, relocate_library, restore_backup,
+};
 pub use persistence::repository::sqlite_repository::SqliteRepository;

--- a/src/infrastructure/mod.rs
+++ b/src/infrastructure/mod.rs
@@ -2,7 +2,5 @@ pub mod external;
 pub mod persistence;
 
 pub use external::ao3::Ao3Fetcher;
-pub use persistence::database::{
-    default_db_path, open_configured_db, relocate_library, restore_backup,
-};
+pub use persistence::database::{open_configured_db, relocate_library, restore_backup};
 pub use persistence::repository::sqlite_repository::SqliteRepository;

--- a/src/infrastructure/persistence/database/connection.rs
+++ b/src/infrastructure/persistence/database/connection.rs
@@ -1,26 +1,12 @@
 use crate::error::FicflowError;
 use crate::infrastructure::persistence::database::migration::run_migrations;
-use dirs_next::data_local_dir;
 use rusqlite::Connection;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-const DB_FILE: &str = "fanfictions.db";
-
 // SQLite writes two sidecar files next to the database in WAL mode; any move
 // or delete of the database has to account for them.
 const SIDECAR_SUFFIXES: [&str; 2] = ["-wal", "-shm"];
-
-/// The platform default library path (`~/.local/share/ficflow/fanfictions.db`
-/// on Linux) — used when no `FICFLOW_DB_PATH` env override and no configured
-/// location are set.
-pub fn default_db_path() -> Result<PathBuf, FicflowError> {
-    let mut path = data_local_dir()
-        .ok_or_else(|| FicflowError::Other("Failed to determine user data directory".into()))?;
-    path.push("ficflow");
-    path.push(DB_FILE);
-    Ok(path)
-}
 
 // Single canonical path to obtain a ready-to-use Connection: create the parent
 // directory, open, migrate, then enable FK enforcement and WAL journaling.

--- a/src/infrastructure/persistence/database/connection.rs
+++ b/src/infrastructure/persistence/database/connection.rs
@@ -2,34 +2,38 @@ use crate::error::FicflowError;
 use crate::infrastructure::persistence::database::migration::run_migrations;
 use dirs_next::data_local_dir;
 use rusqlite::Connection;
-use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-pub fn establish_connection() -> Result<Connection, FicflowError> {
-    let db_path = if let Ok(path) = env::var("FICFLOW_DB_PATH") {
-        PathBuf::from(path)
-    } else {
-        let mut path = data_local_dir()
-            .ok_or_else(|| FicflowError::Other("Failed to determine user data directory".into()))?;
-        path.push("ficflow");
-        fs::create_dir_all(&path)?;
-        path.push("fanfictions.db");
-        path
-    };
+const DB_FILE: &str = "fanfictions.db";
 
-    open_configured_db(&db_path)
+// SQLite writes two sidecar files next to the database in WAL mode; any move
+// or delete of the database has to account for them.
+const SIDECAR_SUFFIXES: [&str; 2] = ["-wal", "-shm"];
+
+/// The platform default library path (`~/.local/share/ficflow/fanfictions.db`
+/// on Linux) — used when no `FICFLOW_DB_PATH` env override and no configured
+/// location are set.
+pub fn default_db_path() -> Result<PathBuf, FicflowError> {
+    let mut path = data_local_dir()
+        .ok_or_else(|| FicflowError::Other("Failed to determine user data directory".into()))?;
+    path.push("ficflow");
+    path.push(DB_FILE);
+    Ok(path)
 }
 
-// Single canonical path to obtain a ready-to-use Connection: open, migrate,
-// then enable FK enforcement and WAL journaling. SQLite FKs are off by
-// default per-connection, so production and test code must go through here
-// to keep cascades working. WAL mode lets the GUI thread's reads and the
-// task-worker thread's writes proceed concurrently — without it, the
-// worker can busy-wait for several seconds while the GUI keeps grabbing
-// SHARED locks during render(), which manifests as tasks stuck on the
+// Single canonical path to obtain a ready-to-use Connection: create the parent
+// directory, open, migrate, then enable FK enforcement and WAL journaling.
+// SQLite FKs are off by default per-connection, so production and test code
+// must go through here to keep cascades working. WAL mode lets the GUI
+// thread's reads and the task-worker thread's writes proceed concurrently —
+// without it, the worker can busy-wait for several seconds while the GUI keeps
+// grabbing SHARED locks during render(), which manifests as tasks stuck on the
 // `Running` state.
 pub fn open_configured_db(path: &Path) -> Result<Connection, FicflowError> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
     let mut conn = Connection::open(path)?;
     run_migrations(&mut conn)?;
     conn.execute_batch(
@@ -37,4 +41,57 @@ pub fn open_configured_db(path: &Path) -> Result<Connection, FicflowError> {
          PRAGMA foreign_keys = ON;",
     )?;
     Ok(conn)
+}
+
+/// Moves the library file (and its `-wal`/`-shm` sidecars) from `from` to `to`.
+/// On Linux a plain rename keeps a live connection's open descriptors valid
+/// through the next restart; if the destination is on another filesystem the
+/// rename fails, so we fall back to copy-then-remove.
+pub fn relocate_library(from: &Path, to: &Path) -> Result<(), FicflowError> {
+    if let Some(parent) = to.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    move_file(from, to)?;
+    for suffix in SIDECAR_SUFFIXES {
+        let from_sidecar = sidecar(from, suffix);
+        if from_sidecar.exists() {
+            move_file(&from_sidecar, &sidecar(to, suffix))?;
+        }
+    }
+    Ok(())
+}
+
+/// Restores a backup by copying `backup` over the current library at `current`
+/// and clearing any stale `-wal`/`-shm` sidecars so the restored file is read
+/// cleanly on the next restart. The configured location is left untouched.
+pub fn restore_backup(backup: &Path, current: &Path) -> Result<(), FicflowError> {
+    if let Some(parent) = current.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::copy(backup, current)?;
+    for suffix in SIDECAR_SUFFIXES {
+        let stale = sidecar(current, suffix);
+        if stale.exists() {
+            fs::remove_file(&stale)?;
+        }
+    }
+    Ok(())
+}
+
+fn move_file(from: &Path, to: &Path) -> Result<(), FicflowError> {
+    match fs::rename(from, to) {
+        Ok(()) => Ok(()),
+        // Cross-device rename isn't allowed; copy then delete the original.
+        Err(_) => {
+            fs::copy(from, to)?;
+            fs::remove_file(from)?;
+            Ok(())
+        }
+    }
+}
+
+fn sidecar(path: &Path, suffix: &str) -> PathBuf {
+    let mut name = path.as_os_str().to_owned();
+    name.push(suffix);
+    PathBuf::from(name)
 }

--- a/src/infrastructure/persistence/database/mod.rs
+++ b/src/infrastructure/persistence/database/mod.rs
@@ -1,4 +1,4 @@
 pub mod connection;
 pub mod migration;
 
-pub use connection::{default_db_path, open_configured_db, relocate_library, restore_backup};
+pub use connection::{open_configured_db, relocate_library, restore_backup};

--- a/src/infrastructure/persistence/database/mod.rs
+++ b/src/infrastructure/persistence/database/mod.rs
@@ -1,4 +1,4 @@
 pub mod connection;
 pub mod migration;
 
-pub use connection::establish_connection;
+pub use connection::{default_db_path, open_configured_db, relocate_library, restore_backup};

--- a/src/infrastructure/persistence/mod.rs
+++ b/src/infrastructure/persistence/mod.rs
@@ -1,5 +1,7 @@
 pub mod database;
 pub mod repository;
 
-pub use database::connection::establish_connection;
+pub use database::connection::{
+    default_db_path, open_configured_db, relocate_library, restore_backup,
+};
 pub use repository::sqlite_repository::SqliteRepository;

--- a/src/infrastructure/persistence/mod.rs
+++ b/src/infrastructure/persistence/mod.rs
@@ -1,7 +1,5 @@
 pub mod database;
 pub mod repository;
 
-pub use database::connection::{
-    default_db_path, open_configured_db, relocate_library, restore_backup,
-};
+pub use database::connection::{open_configured_db, relocate_library, restore_backup};
 pub use repository::sqlite_repository::SqliteRepository;

--- a/src/interfaces/gui/app.rs
+++ b/src/interfaces/gui/app.rs
@@ -16,9 +16,7 @@ use crate::domain::shelf::{AutoShelfCriteria, Shelf, ShelfKind};
 use crate::error::FicflowError;
 use crate::infrastructure::SqliteRepository;
 use crate::infrastructure::external::ao3::fetcher::ao3_urls_from_env;
-use crate::infrastructure::persistence::database::connection::{
-    establish_connection, open_configured_db,
-};
+use crate::infrastructure::persistence::database::connection::open_configured_db;
 
 use super::chrome::FrameChrome;
 use super::library_cache::LibraryCache;
@@ -128,13 +126,14 @@ impl FicflowApp {
     /// `Connection: !Send`.
     pub fn with_config(ctx: &egui::Context, config: FicflowConfig) -> Result<Self, InitError> {
         theme::install(ctx);
-        let connection = match &config.db_path {
-            Some(path) => open_configured_db(path).map_err(InitError::Database)?,
-            None => establish_connection().map_err(InitError::Database)?,
+        let mut app_config = AppConfig::load();
+        let db_path = match &config.db_path {
+            Some(path) => path.clone(),
+            None => app_config.resolved_db_path().map_err(InitError::Database)?,
         };
+        let connection = open_configured_db(&db_path).map_err(InitError::Database)?;
         let cache = LibraryCache::load(&connection);
         let chrome = FrameChrome::new().map_err(InitError::Chrome)?;
-        let mut app_config = AppConfig::load();
         app_config.text_zoom = config::set_zoom(ctx, app_config.text_zoom);
         config::set_theme(ctx, app_config.theme);
         let sort = app_config.default_sort;
@@ -142,11 +141,8 @@ impl FicflowApp {
             .last_view
             .and_then(|pv| View::from_persisted(pv, &cache.shelves))
             .unwrap_or_default();
-        let task_executor = TaskExecutor::spawn(
-            config.ao3_urls,
-            config.max_retry_cycles,
-            config.db_path.clone(),
-        );
+        let task_executor =
+            TaskExecutor::spawn(config.ao3_urls, config.max_retry_cycles, db_path.clone());
         let mut app = Self {
             connection,
             cache,

--- a/src/interfaces/gui/app.rs
+++ b/src/interfaces/gui/app.rs
@@ -16,7 +16,9 @@ use crate::domain::shelf::{AutoShelfCriteria, Shelf, ShelfKind};
 use crate::error::FicflowError;
 use crate::infrastructure::SqliteRepository;
 use crate::infrastructure::external::ao3::fetcher::ao3_urls_from_env;
-use crate::infrastructure::persistence::database::connection::open_configured_db;
+use crate::infrastructure::persistence::database::connection::{
+    open_configured_db, relocate_library, restore_backup,
+};
 
 use super::chrome::FrameChrome;
 use super::library_cache::LibraryCache;
@@ -28,7 +30,7 @@ use super::view::View;
 use super::views::details_panel::DetailsState;
 use super::views::modals::add_fic_dialog::{self, AddFicState};
 use super::views::modals::shelf_modals::{self, AutoShelfState, CreateState, RenameState};
-use super::views::modals::{bulk_modals, column_picker, quit_modal};
+use super::views::modals::{bulk_modals, column_picker, quit_modal, restore_modal};
 use super::views::settings_view;
 use super::views::tasks_view;
 use super::views::{
@@ -38,6 +40,10 @@ use super::views::{
 
 pub struct FicflowApp {
     connection: Connection,
+    /// The library file the live `connection` was opened from. Also the
+    /// source when the user relocates the library and the target that a
+    /// restored backup is copied over.
+    current_db_path: PathBuf,
     cache: LibraryCache,
     chrome: FrameChrome,
     config: AppConfig,
@@ -93,6 +99,7 @@ pub enum ActiveModal {
     RemoveOrDeleteFics { ids: Vec<u64>, shelf_id: u64 },
     AddFic(AddFicState),
     ConfirmQuit,
+    ConfirmRestore(PathBuf),
 }
 
 /// Explicit wiring so embedders and integration tests can inject a
@@ -145,6 +152,7 @@ impl FicflowApp {
             TaskExecutor::spawn(config.ao3_urls, config.max_retry_cycles, db_path.clone());
         let mut app = Self {
             connection,
+            current_db_path: db_path,
             cache,
             chrome,
             config: app_config,
@@ -581,6 +589,52 @@ impl FicflowApp {
     fn save_config(&self) {
         if let Err(err) = self.config.save() {
             log::warn!("Failed to save config: {}", err);
+        }
+    }
+
+    /// Move the library into `folder`, keeping the current file name. If a
+    /// library already lives there, adopt it in place rather than
+    /// overwriting. Takes effect on the next restart.
+    fn change_library_location(&mut self, folder: PathBuf) {
+        let Some(file_name) = self.current_db_path.file_name() else {
+            return;
+        };
+        let target = folder.join(file_name);
+        if target == self.current_db_path {
+            return;
+        }
+        let result = if target.exists() {
+            Ok(())
+        } else {
+            relocate_library(&self.current_db_path, &target)
+        };
+        match result {
+            Ok(()) => {
+                self.config.library_path = Some(target.clone());
+                self.current_db_path = target;
+                self.save_config();
+                self.toasts
+                    .info("Library location updated — restart Ficflow to load it.");
+            }
+            Err(err) => {
+                self.toasts
+                    .error(format!("Couldn't move the library: {}", err));
+            }
+        }
+    }
+
+    /// Copy a backup over the current library, leaving the configured
+    /// location unchanged. Takes effect on the next restart.
+    fn restore_library_backup(&mut self, backup: PathBuf) {
+        match restore_backup(&backup, &self.current_db_path) {
+            Ok(()) => {
+                self.toasts
+                    .info("Backup restored — restart Ficflow to load it.");
+            }
+            Err(err) => {
+                self.toasts
+                    .error(format!("Couldn't restore the backup: {}", err));
+            }
         }
     }
 
@@ -1082,8 +1136,18 @@ impl FicflowApp {
                     },
                 );
             } else if matches!(self.current_view, View::Settings) {
-                if settings_view::draw(ui, &mut self.config) {
+                let outcome = settings_view::draw(ui, &mut self.config, &self.current_db_path);
+                if outcome.config_changed {
                     self.save_config();
+                }
+                match outcome.action {
+                    Some(settings_view::LibraryAction::ChangeLocation(folder)) => {
+                        self.change_library_location(folder);
+                    }
+                    Some(settings_view::LibraryAction::Restore(backup)) => {
+                        self.active_modal = ActiveModal::ConfirmRestore(backup);
+                    }
+                    None => {}
                 }
             } else {
                 draw_stub_view(ui, &self.current_view);
@@ -1155,6 +1219,7 @@ impl FicflowApp {
                 shelf_id: u64,
             },
             AddFic(String),
+            RestoreBackup(PathBuf),
             Quit,
         }
         let action = match &mut self.active_modal {
@@ -1234,6 +1299,11 @@ impl FicflowApp {
                     quit_modal::Outcome::None => ModalAction::None,
                 }
             }
+            ActiveModal::ConfirmRestore(backup) => match restore_modal::draw_confirm(ctx, backup) {
+                restore_modal::Outcome::Confirm => ModalAction::RestoreBackup(backup.clone()),
+                restore_modal::Outcome::Cancel => ModalAction::Close,
+                restore_modal::Outcome::None => ModalAction::None,
+            },
         };
         match action {
             ModalAction::None => {}
@@ -1272,6 +1342,10 @@ impl FicflowApp {
             }
             ModalAction::AddFic(input) => {
                 self.task_executor.enqueue_add(input);
+                self.active_modal = ActiveModal::None;
+            }
+            ModalAction::RestoreBackup(backup) => {
+                self.restore_library_backup(backup);
                 self.active_modal = ActiveModal::None;
             }
             ModalAction::Quit => {

--- a/src/interfaces/gui/app.rs
+++ b/src/interfaces/gui/app.rs
@@ -56,6 +56,9 @@ pub struct FicflowApp {
     selection: SelectionController,
     current_view: View,
     active_modal: ActiveModal,
+    /// A Library button was clicked this frame; the native picker is opened
+    /// from `ui()` next, where the window handle is available to parent it.
+    pending_library_request: Option<settings_view::LibraryRequest>,
     task_executor: TaskExecutor,
     quit_confirmed: bool,
     task_filter: TaskFilter,
@@ -163,6 +166,7 @@ impl FicflowApp {
             selection: SelectionController::new(),
             current_view,
             active_modal: ActiveModal::None,
+            pending_library_request: None,
             task_executor,
             quit_confirmed: false,
             task_filter: TaskFilter::default(),
@@ -592,6 +596,39 @@ impl FicflowApp {
         }
     }
 
+    /// Opens the native folder/file picker for a Library action, parented to
+    /// our own window so the portal dialog stacks above Ficflow instead of
+    /// behind it. Called from `ui()`, the only place with a window handle.
+    fn open_library_picker(
+        &mut self,
+        request: settings_view::LibraryRequest,
+        frame: &eframe::Frame,
+    ) {
+        let start_dir = self.current_db_path.parent().map(|p| p.to_path_buf());
+        match request {
+            settings_view::LibraryRequest::ChangeLocation => {
+                let mut dialog = rfd::FileDialog::new().set_parent(frame);
+                if let Some(dir) = &start_dir {
+                    dialog = dialog.set_directory(dir);
+                }
+                if let Some(folder) = dialog.pick_folder() {
+                    self.change_library_location(folder);
+                }
+            }
+            settings_view::LibraryRequest::Restore => {
+                let mut dialog = rfd::FileDialog::new()
+                    .add_filter("SQLite database", &["db"])
+                    .set_parent(frame);
+                if let Some(dir) = &start_dir {
+                    dialog = dialog.set_directory(dir);
+                }
+                if let Some(backup) = dialog.pick_file() {
+                    self.active_modal = ActiveModal::ConfirmRestore(backup);
+                }
+            }
+        }
+    }
+
     /// Move the library into `folder`, keeping the current file name. If a
     /// library already lives there, adopt it in place rather than
     /// overwriting. Takes effect on the next restart.
@@ -835,8 +872,11 @@ fn compute_library_counts(fics: &[Fanfiction]) -> LibraryCounts {
 }
 
 impl eframe::App for FicflowApp {
-    fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+    fn ui(&mut self, ui: &mut egui::Ui, frame: &mut eframe::Frame) {
         self.render(ui);
+        if let Some(request) = self.pending_library_request.take() {
+            self.open_library_picker(request, frame);
+        }
     }
 
     /// Transparent so the chrome's painted edges show through the
@@ -1140,14 +1180,10 @@ impl FicflowApp {
                 if outcome.config_changed {
                     self.save_config();
                 }
-                match outcome.action {
-                    Some(settings_view::LibraryAction::ChangeLocation(folder)) => {
-                        self.change_library_location(folder);
-                    }
-                    Some(settings_view::LibraryAction::Restore(backup)) => {
-                        self.active_modal = ActiveModal::ConfirmRestore(backup);
-                    }
-                    None => {}
+                // The native picker is opened later from `ui()`, which holds
+                // the window handle needed to parent the dialog above us.
+                if outcome.request.is_some() {
+                    self.pending_library_request = outcome.request;
                 }
             } else {
                 draw_stub_view(ui, &self.current_view);

--- a/src/interfaces/gui/app.rs
+++ b/src/interfaces/gui/app.rs
@@ -596,6 +596,21 @@ impl FicflowApp {
         }
     }
 
+    /// Fold the write-ahead log back into the main database file on exit so a
+    /// cleanly-closed library is a single self-contained `.db` — this empties
+    /// the `-wal` sidecar and makes "copy the file to back it up" reliable.
+    /// Best-effort: the worker thread may still hold the WAL open, in which
+    /// case SQLite still flushes committed frames into the `.db` even if it
+    /// can't fully truncate the log.
+    fn checkpoint_wal(&self) {
+        if let Err(err) = self
+            .connection
+            .execute_batch("PRAGMA wal_checkpoint(TRUNCATE);")
+        {
+            log::warn!("Failed to checkpoint the database on exit: {}", err);
+        }
+    }
+
     /// Opens the native folder/file picker for a Library action, parented to
     /// our own window so the portal dialog stacks above Ficflow instead of
     /// behind it. Called from `ui()`, the only place with a window handle.
@@ -883,6 +898,10 @@ impl eframe::App for FicflowApp {
     /// borderless undecorated window (see NativeOptions in `mod.rs`).
     fn clear_color(&self, _visuals: &egui::Visuals) -> [f32; 4] {
         [0.0, 0.0, 0.0, 0.0]
+    }
+
+    fn on_exit(&mut self) {
+        self.checkpoint_wal();
     }
 }
 

--- a/src/interfaces/gui/config.rs
+++ b/src/interfaces/gui/config.rs
@@ -1,19 +1,27 @@
-//! Persistent GUI preferences stored as TOML at the platform's config
+//! Persistent app preferences stored as TOML at the platform's config
 //! dir (`~/.config/ficflow/config.toml` on Linux). Holds visible
 //! columns, the default sort for the library table, the
-//! maximized/fullscreen window state, the text-zoom level, and the
-//! theme choice — read at startup, written when the user changes them.
+//! maximized/fullscreen window state, the text-zoom level, the theme
+//! choice, and the library location — read at startup, written when the
+//! user changes them.
 //!
-//! Lives under `interfaces/gui/` because every field here is a GUI
-//! concern: column visibility, sort direction, and window state have
-//! no meaning to the CLI.
+//! Lives under `interfaces/gui/` because almost every field is a GUI
+//! concern with no meaning to the CLI. The one exception is
+//! `library_path`: it's the single source of truth for where the
+//! database lives, so both the GUI and the CLI resolve it through
+//! `resolved_db_path`.
 
+use std::env;
 use std::io;
 use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
 use crate::domain::fanfiction::ReadingStatus;
+use crate::error::FicflowError;
+use crate::infrastructure::persistence::database::connection::default_db_path;
+
+const DB_PATH_ENV: &str = "FICFLOW_DB_PATH";
 
 const CONFIG_FILE: &str = "config.toml";
 const APP_DIR: &str = "ficflow";
@@ -165,6 +173,10 @@ pub struct AppConfig {
     pub text_zoom: f32,
     #[serde(default)]
     pub theme: ThemeChoice,
+    /// Where the library database lives. `None` means the platform
+    /// default. Shared with the CLI via `resolved_db_path`.
+    #[serde(default)]
+    pub library_path: Option<PathBuf>,
 }
 
 pub const TEXT_ZOOM_RANGE: std::ops::RangeInclusive<f32> = 0.5..=2.0;
@@ -213,6 +225,7 @@ impl Default for AppConfig {
             last_view: None,
             text_zoom: 1.0,
             theme: ThemeChoice::System,
+            library_path: None,
         }
     }
 }
@@ -233,6 +246,19 @@ impl AppConfig {
                 log::warn!("Ignoring unparseable config at {:?}: {}", path, err);
                 Self::default()
             }
+        }
+    }
+
+    /// The effective library path, in precedence order: the
+    /// `FICFLOW_DB_PATH` env override, then the configured `library_path`,
+    /// then the platform default.
+    pub fn resolved_db_path(&self) -> Result<PathBuf, FicflowError> {
+        if let Ok(path) = env::var(DB_PATH_ENV) {
+            return Ok(PathBuf::from(path));
+        }
+        match &self.library_path {
+            Some(path) => Ok(path.clone()),
+            None => default_db_path(),
         }
     }
 

--- a/src/interfaces/gui/config.rs
+++ b/src/interfaces/gui/config.rs
@@ -19,11 +19,11 @@ use serde::{Deserialize, Serialize};
 
 use crate::domain::fanfiction::ReadingStatus;
 use crate::error::FicflowError;
-use crate::infrastructure::persistence::database::connection::default_db_path;
 
 const DB_PATH_ENV: &str = "FICFLOW_DB_PATH";
 
 const CONFIG_FILE: &str = "config.toml";
+const DB_FILE: &str = "fanfictions.db";
 const APP_DIR: &str = "ficflow";
 
 /// Serializable shadow of the library-facing `View` variants — the ones
@@ -301,4 +301,14 @@ impl AppConfig {
 
 fn config_path() -> Option<PathBuf> {
     dirs_next::config_dir().map(|d| d.join(APP_DIR).join(CONFIG_FILE))
+}
+
+/// The platform default library path (`~/.local/share/ficflow/fanfictions.db`
+/// on Linux), used when neither `FICFLOW_DB_PATH` nor `library_path` is set.
+fn default_db_path() -> Result<PathBuf, FicflowError> {
+    let mut path = dirs_next::data_local_dir()
+        .ok_or_else(|| FicflowError::Other("Failed to determine user data directory".into()))?;
+    path.push(APP_DIR);
+    path.push(DB_FILE);
+    Ok(path)
 }

--- a/src/interfaces/gui/tasks/mod.rs
+++ b/src/interfaces/gui/tasks/mod.rs
@@ -79,8 +79,8 @@ pub struct TaskExecutor {
 impl TaskExecutor {
     /// Worker opens its own SQLite connection (`Connection: !Send`); it
     /// must point at the same file as the GUI's so writes are visible
-    /// to subsequent reads. `None` falls through to `establish_connection()`.
-    pub fn spawn(urls: Vec<String>, max_cycles: u32, db_path: Option<PathBuf>) -> Self {
+    /// to subsequent reads, hence the shared `db_path`.
+    pub fn spawn(urls: Vec<String>, max_cycles: u32, db_path: PathBuf) -> Self {
         let inbox = Arc::new(WorkerInbox::new());
         let (tx, rx) = mpsc::channel();
         let worker_inbox = Arc::clone(&inbox);

--- a/src/interfaces/gui/tasks/worker.rs
+++ b/src/interfaces/gui/tasks/worker.rs
@@ -8,9 +8,7 @@ use crate::application::check_updates::check_fic_updates;
 use crate::error::FicflowError;
 use crate::infrastructure::SqliteRepository;
 use crate::infrastructure::external::ao3::fetcher::Ao3Fetcher;
-use crate::infrastructure::persistence::database::connection::{
-    establish_connection, open_configured_db,
-};
+use crate::infrastructure::persistence::database::connection::open_configured_db;
 use crate::interfaces::utils::url_parser::extract_ao3_id;
 
 use super::{TaskStatus, WorkerCommand, WorkerInbox};
@@ -20,15 +18,11 @@ pub fn run(
     inbox: Arc<WorkerInbox>,
     urls: Vec<String>,
     max_cycles: u32,
-    db_path: Option<PathBuf>,
+    db_path: PathBuf,
 ) {
-    // Mirror the GUI's connection override so the worker writes land in
-    // the same SQLite file the GUI reads from.
-    let conn_result = match db_path {
-        Some(ref path) => open_configured_db(path),
-        None => establish_connection(),
-    };
-    let conn = match conn_result {
+    // Open the same SQLite file the GUI reads from so the worker's writes
+    // are visible to subsequent reads.
+    let conn = match open_configured_db(&db_path) {
         Ok(c) => c,
         Err(err) => {
             log::error!("task worker couldn't open DB: {}", err);

--- a/src/interfaces/gui/views/modals/mod.rs
+++ b/src/interfaces/gui/views/modals/mod.rs
@@ -8,4 +8,5 @@ pub mod add_fic_dialog;
 pub mod bulk_modals;
 pub mod column_picker;
 pub mod quit_modal;
+pub mod restore_modal;
 pub mod shelf_modals;

--- a/src/interfaces/gui/views/modals/restore_modal.rs
+++ b/src/interfaces/gui/views/modals/restore_modal.rs
@@ -1,0 +1,47 @@
+use std::path::Path;
+
+use egui::{Context, Window};
+
+pub enum Outcome {
+    None,
+    Confirm,
+    Cancel,
+}
+
+pub fn draw_confirm(ctx: &Context, backup: &Path) -> Outcome {
+    let mut still_open = true;
+    let mut outcome = Outcome::None;
+    Window::new("Restore backup")
+        .open(&mut still_open)
+        .resizable(false)
+        .collapsible(false)
+        .pivot(egui::Align2::CENTER_CENTER)
+        .default_pos(ctx.content_rect().center())
+        .show(ctx, |ui| {
+            ui.label("Replace your current library with this backup?");
+            ui.label(
+                egui::RichText::new(backup.display().to_string())
+                    .weak()
+                    .italics(),
+            );
+            ui.add_space(6.0);
+            ui.label(
+                egui::RichText::new("Your current library will be overwritten.")
+                    .weak()
+                    .italics(),
+            );
+            ui.add_space(6.0);
+            ui.horizontal(|ui| {
+                if ui.button("Restore").clicked() {
+                    outcome = Outcome::Confirm;
+                }
+                if ui.button("Cancel").clicked() {
+                    outcome = Outcome::Cancel;
+                }
+            });
+        });
+    if !still_open {
+        outcome = Outcome::Cancel;
+    }
+    outcome
+}

--- a/src/interfaces/gui/views/settings_view.rs
+++ b/src/interfaces/gui/views/settings_view.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use chrono::NaiveDate;
 use egui::{RichText, ScrollArea, Ui};
@@ -9,19 +9,22 @@ use crate::version::{LICENSE, RELEASE_DATE, VERSION};
 
 const ZOOM_STEP: f32 = 0.1;
 
-pub enum LibraryAction {
-    ChangeLocation(PathBuf),
-    Restore(PathBuf),
+/// A click on one of the Library buttons. The native file picker is opened
+/// by the app layer (which owns the window handle needed to parent the
+/// dialog), not here.
+pub enum LibraryRequest {
+    ChangeLocation,
+    Restore,
 }
 
 pub struct SettingsOutcome {
     pub config_changed: bool,
-    pub action: Option<LibraryAction>,
+    pub request: Option<LibraryRequest>,
 }
 
 pub fn draw(ui: &mut Ui, config: &mut AppConfig, current_db_path: &Path) -> SettingsOutcome {
     let mut changed = false;
-    let mut action = None;
+    let mut request = None;
 
     ScrollArea::vertical()
         .auto_shrink([false; 2])
@@ -85,25 +88,12 @@ pub fn draw(ui: &mut Ui, config: &mut AppConfig, current_db_path: &Path) -> Sett
             ui.add_space(12.0);
             ui.label(RichText::new("Library").strong());
             info_row(ui, "Location", current_db_path.display().to_string());
-            let start_dir = current_db_path
-                .parent()
-                .unwrap_or_else(|| Path::new("."))
-                .to_path_buf();
             ui.horizontal(|ui| {
-                if ui.button("Change location…").clicked()
-                    && let Some(folder) = rfd::FileDialog::new()
-                        .set_directory(&start_dir)
-                        .pick_folder()
-                {
-                    action = Some(LibraryAction::ChangeLocation(folder));
+                if ui.button("Change location…").clicked() {
+                    request = Some(LibraryRequest::ChangeLocation);
                 }
-                if ui.button("Restore from backup…").clicked()
-                    && let Some(file) = rfd::FileDialog::new()
-                        .add_filter("SQLite database", &["db"])
-                        .set_directory(&start_dir)
-                        .pick_file()
-                {
-                    action = Some(LibraryAction::Restore(file));
+                if ui.button("Restore from backup…").clicked() {
+                    request = Some(LibraryRequest::Restore);
                 }
             });
             ui.label(
@@ -123,7 +113,7 @@ pub fn draw(ui: &mut Ui, config: &mut AppConfig, current_db_path: &Path) -> Sett
 
     SettingsOutcome {
         config_changed: changed,
-        action,
+        request,
     }
 }
 

--- a/src/interfaces/gui/views/settings_view.rs
+++ b/src/interfaces/gui/views/settings_view.rs
@@ -1,3 +1,5 @@
+use std::path::{Path, PathBuf};
+
 use chrono::NaiveDate;
 use egui::{RichText, ScrollArea, Ui};
 
@@ -7,8 +9,19 @@ use crate::version::{LICENSE, RELEASE_DATE, VERSION};
 
 const ZOOM_STEP: f32 = 0.1;
 
-pub fn draw(ui: &mut Ui, config: &mut AppConfig) -> bool {
+pub enum LibraryAction {
+    ChangeLocation(PathBuf),
+    Restore(PathBuf),
+}
+
+pub struct SettingsOutcome {
+    pub config_changed: bool,
+    pub action: Option<LibraryAction>,
+}
+
+pub fn draw(ui: &mut Ui, config: &mut AppConfig, current_db_path: &Path) -> SettingsOutcome {
     let mut changed = false;
+    let mut action = None;
 
     ScrollArea::vertical()
         .auto_shrink([false; 2])
@@ -72,12 +85,48 @@ pub fn draw(ui: &mut Ui, config: &mut AppConfig) -> bool {
             });
 
             ui.add_space(12.0);
+            ui.label(RichText::new("Library").strong());
+            info_row(ui, "Location", current_db_path.display().to_string());
+            let start_dir = current_db_path
+                .parent()
+                .unwrap_or_else(|| Path::new("."))
+                .to_path_buf();
+            ui.horizontal(|ui| {
+                if ui.button("Change location…").clicked()
+                    && let Some(folder) = rfd::FileDialog::new()
+                        .set_directory(&start_dir)
+                        .pick_folder()
+                {
+                    action = Some(LibraryAction::ChangeLocation(folder));
+                }
+                if ui.button("Restore from backup…").clicked()
+                    && let Some(file) = rfd::FileDialog::new()
+                        .add_filter("SQLite database", &["db"])
+                        .set_directory(&start_dir)
+                        .pick_file()
+                {
+                    action = Some(LibraryAction::Restore(file));
+                }
+            });
+            ui.label(
+                RichText::new(
+                    "Copy this file elsewhere to back up your library. Restore replaces your \
+                    current library with a backup .db, copying it here without changing the \
+                    location above. Changes take effect after a restart.",
+                )
+                .weak()
+                .italics(),
+            );
+
+            ui.add_space(12.0);
             ui.label(RichText::new("Paths").strong());
-            info_row(ui, "Database", db_path_display());
             info_row(ui, "Config", config_path_display());
         });
 
-    changed
+    SettingsOutcome {
+        config_changed: changed,
+        action,
+    }
 }
 
 fn apply_zoom(config: &mut AppConfig, changed: &mut bool, ctx: &egui::Context, zoom: f32) {
@@ -91,18 +140,6 @@ fn info_row(ui: &mut Ui, name: &str, value: String) -> egui::Response {
         ui.add(egui::Label::new(value).selectable(true).truncate())
     })
     .inner
-}
-
-/// Database path, mirroring `establish_connection()`'s logic so what we show
-/// is what the app actually uses.
-fn db_path_display() -> String {
-    if let Ok(path) = std::env::var("FICFLOW_DB_PATH") {
-        return format!("{}  (from FICFLOW_DB_PATH)", path);
-    }
-    match dirs_next::data_local_dir().map(|d| d.join("ficflow").join("fanfictions.db")) {
-        Some(p) => p.display().to_string(),
-        None => "<unavailable>".to_string(),
-    }
 }
 
 fn config_path_display() -> String {

--- a/src/interfaces/gui/views/settings_view.rs
+++ b/src/interfaces/gui/views/settings_view.rs
@@ -27,8 +27,6 @@ pub fn draw(ui: &mut Ui, config: &mut AppConfig, current_db_path: &Path) -> Sett
         .auto_shrink([false; 2])
         .show(ui, |ui| {
             ui.add_space(8.0);
-            ui.heading("Settings");
-            ui.add_space(12.0);
 
             ui.label(RichText::new("Application").strong());
             info_row(ui, "Version", VERSION.to_string());

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,8 @@
 use std::process::ExitCode;
 
 use ficflow::infrastructure::external::ao3::fetcher::ao3_urls_from_env;
-use ficflow::infrastructure::{Ao3Fetcher, SqliteRepository, establish_connection};
+use ficflow::infrastructure::{Ao3Fetcher, SqliteRepository, open_configured_db};
+use ficflow::interfaces::gui::AppConfig;
 
 fn main() -> ExitCode {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
@@ -18,7 +19,10 @@ fn main() -> ExitCode {
         // synchronous and trait-object-based.
         let (urls, max_cycles) = ao3_urls_from_env();
         let fetcher = Ao3Fetcher::new(urls, max_cycles).expect("Failed to create Ao3Fetcher");
-        let conn = establish_connection().expect("Failed to establish database connection");
+        let db_path = AppConfig::load()
+            .resolved_db_path()
+            .expect("Failed to resolve library path");
+        let conn = open_configured_db(&db_path).expect("Failed to establish database connection");
         let repository = SqliteRepository::new(&conn);
         ficflow::interfaces::cli::run_cli(&fetcher, &repository)
     }

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -310,4 +310,92 @@ mod tests {
 
         Ok(())
     }
+
+    fn binary_path() -> PathBuf {
+        env::current_dir()
+            .unwrap()
+            .join("target")
+            .join("debug")
+            .join("ficflow")
+    }
+
+    fn write_config_with_library_path(config_home: &Path, library_path: &Path) {
+        let cfg = ficflow::interfaces::gui::AppConfig {
+            library_path: Some(library_path.to_path_buf()),
+            ..ficflow::interfaces::gui::AppConfig::default()
+        };
+        let dir = config_home.join("ficflow");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("config.toml"),
+            toml::to_string_pretty(&cfg).unwrap(),
+        )
+        .unwrap();
+    }
+
+    fn run_cli(args: &[&str], config_home: &Path, db_env: Option<&Path>) -> (String, i32) {
+        let mut cmd = Command::new(binary_path());
+        cmd.env("XDG_CONFIG_HOME", config_home)
+            .env_remove("FICFLOW_DB_PATH");
+        if let Some(path) = db_env {
+            cmd.env("FICFLOW_DB_PATH", path);
+        }
+        for arg in args {
+            cmd.arg(arg);
+        }
+        let output = cmd.output().expect("Failed to execute command");
+        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+        (stdout, output.status.code().unwrap_or(0))
+    }
+
+    #[test]
+    fn cli_reads_and_writes_the_configured_library_path() -> Result<(), Box<dyn Error>> {
+        let config_home = TempDir::new()?;
+        let lib_dir = TempDir::new()?;
+        let configured_db = lib_dir.path().join("my-library.db");
+        write_config_with_library_path(config_home.path(), &configured_db);
+
+        let (_, create_status) =
+            run_cli(&["shelf", "create", "Configured"], config_home.path(), None);
+        assert_eq!(create_status, 0);
+        assert!(
+            configured_db.exists(),
+            "CLI should create the DB at the configured path"
+        );
+
+        let (list_out, _) = run_cli(&["shelf", "list"], config_home.path(), None);
+        assert!(
+            list_out.contains("Configured"),
+            "CLI should read back from the configured library; got: {}",
+            list_out
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn ficflow_db_path_env_overrides_the_configured_library_path() -> Result<(), Box<dyn Error>> {
+        let config_home = TempDir::new()?;
+        let config_lib = TempDir::new()?;
+        let configured_db = config_lib.path().join("configured.db");
+        write_config_with_library_path(config_home.path(), &configured_db);
+
+        let env_lib = TempDir::new()?;
+        let env_db = env_lib.path().join("env.db");
+
+        let (_, status) = run_cli(
+            &["shelf", "create", "FromEnv"],
+            config_home.path(),
+            Some(&env_db),
+        );
+        assert_eq!(status, 0);
+        assert!(
+            env_db.exists(),
+            "env override should decide the library path"
+        );
+        assert!(
+            !configured_db.exists(),
+            "configured path must be ignored when FICFLOW_DB_PATH is set"
+        );
+        Ok(())
+    }
 }

--- a/tests/infrastructure.rs
+++ b/tests/infrastructure.rs
@@ -7,6 +7,8 @@ mod ao3;
 mod ao3_real;
 #[path = "infrastructure/db.rs"]
 mod db;
+#[path = "infrastructure/library_location.rs"]
+mod library_location;
 #[path = "infrastructure/shelf.rs"]
 mod shelf;
 #[path = "infrastructure/url_parser.rs"]

--- a/tests/infrastructure/library_location.rs
+++ b/tests/infrastructure/library_location.rs
@@ -1,0 +1,79 @@
+use std::error::Error;
+use std::fs;
+use tempfile::TempDir;
+
+use crate::common::{assertions, fixtures};
+
+#[cfg(test)]
+mod tests {
+    use ficflow::infrastructure::persistence::database::connection::{
+        open_configured_db, relocate_library, restore_backup,
+    };
+
+    use super::*;
+
+    #[test]
+    fn relocate_moves_database_and_sidecars_and_preserves_data() -> Result<(), Box<dyn Error>> {
+        let src_dir = TempDir::new()?;
+        let from = src_dir.path().join("fanfictions.db");
+        let conn = open_configured_db(&from)?;
+        let fic = fixtures::given_sample_fanfiction(1, "Relocated Fic");
+        fixtures::when_fanfiction_added_to_db(&conn, &fic)?;
+        drop(conn);
+        fs::write(src_dir.path().join("fanfictions.db-wal"), b"wal")?;
+        fs::write(src_dir.path().join("fanfictions.db-shm"), b"shm")?;
+
+        let dest_dir = TempDir::new()?;
+        let to = dest_dir.path().join("moved.db");
+        relocate_library(&from, &to)?;
+
+        assert!(!from.exists());
+        assert!(to.exists());
+        assert!(dest_dir.path().join("moved.db-wal").exists());
+        assert!(dest_dir.path().join("moved.db-shm").exists());
+
+        let moved = open_configured_db(&to)?;
+        assertions::then_fanfiction_was_added(&moved, &fic)?;
+        Ok(())
+    }
+
+    #[test]
+    fn relocate_creates_missing_destination_directory() -> Result<(), Box<dyn Error>> {
+        let src_dir = TempDir::new()?;
+        let from = src_dir.path().join("fanfictions.db");
+        drop(open_configured_db(&from)?);
+
+        let dest_dir = TempDir::new()?;
+        let to = dest_dir.path().join("nested").join("deeper").join("lib.db");
+        relocate_library(&from, &to)?;
+
+        assert!(to.exists());
+        Ok(())
+    }
+
+    #[test]
+    fn restore_overwrites_current_with_backup_and_clears_sidecars() -> Result<(), Box<dyn Error>> {
+        let backup_dir = TempDir::new()?;
+        let backup = backup_dir.path().join("backup.db");
+        let backup_conn = open_configured_db(&backup)?;
+        let fic = fixtures::given_sample_fanfiction(42, "Backed-up Fic");
+        fixtures::when_fanfiction_added_to_db(&backup_conn, &fic)?;
+        drop(backup_conn);
+
+        let current_dir = TempDir::new()?;
+        let current = current_dir.path().join("fanfictions.db");
+        let current_conn = open_configured_db(&current)?;
+        let other = fixtures::given_sample_fanfiction(7, "Current Fic");
+        fixtures::when_fanfiction_added_to_db(&current_conn, &other)?;
+        drop(current_conn);
+        fs::write(current_dir.path().join("fanfictions.db-wal"), b"stale")?;
+
+        restore_backup(&backup, &current)?;
+
+        assert!(!current_dir.path().join("fanfictions.db-wal").exists());
+        let restored = open_configured_db(&current)?;
+        assertions::then_fanfiction_was_added(&restored, &fic)?;
+        assertions::then_fanfiction_was_deleted(&restored, other.id)?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
## What

Makes the library (the `fanfictions.db` SQLite file) location user-customizable instead of fixed at `~/.local/share/ficflow/fanfictions.db`. Adds two actions to **Settings → Paths → Library**:

- **Change location…** — moves the database (and its WAL sidecars) into a chosen folder and persists the new path in the config. Adopts an existing library in place if one already lives there.
- **Restore from backup…** — copies a chosen `.db` over the current library (behind a confirm dialog), without changing the configured location.

Both apply on the next restart (a toast says so). Helper text explains that copying the file elsewhere is how you back up.

## How

- Single source of truth for the path: `AppConfig::resolved_db_path` resolves `FICFLOW_DB_PATH` env → the new `library_path` config field → the platform default. Both the **GUI and the CLI** resolve through it, so they can't drift onto different databases.
- The path was previously recomputed in three places; those are collapsed onto the resolver, and the now-vestigial `establish_connection` is removed. `open_configured_db` creates the parent directory on demand.
- New infra primitives `relocate_library` / `restore_backup` handle the file moves/copies including `-wal`/`-shm` sidecars. The native folder/file pickers use `rfd` (xdg-portal backend, no GTK build dependency).

## Tests

- e2e: CLI reads/writes the configured `library_path`; `FICFLOW_DB_PATH` overrides the config.
- infra: relocate moves DB + sidecars and preserves data; relocate creates missing dirs; restore overwrites and clears stale sidecars.
- Full suite green (e2e 7, gui 71, infra 55), clippy clean.

Closes the roadmap item "choose the location of the library … with persistence of that config".

## Notes

The `rfd` native dialogs can't be driven headlessly, so the move/restore logic lives in pure, tested functions (`relocate_library`, `restore_backup`) separate from the dialog callbacks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)